### PR TITLE
Update requirements.txt until tinydb 4 is supported

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask>=0.11
 requests
 pycryptodome
-tinydb
+tinydb==3.15.2
 pandas


### PR DESCRIPTION
When `tinydb` moved from version 3.15.2 to 4.0.0, the arguments to `Table.get` changed: `eid` is no longer a valid keyword.

HXTool still uses the old arguments, for example at: https://github.com/fireeye/HXTool/blob/3d553183bcb330ac305f581c7c99415b98bf62f3/hxtool_db.py#L52
```
Traceback (most recent call last):
  File ".\hxtool.py", line 565, in <module>
    app_init(debug_mode)
  File ".\hxtool.py", line 478, in app_init
    hxtool_global.hxtool_db = hxtool_db(combine_app_path(hxtool_vars.data_path, 'hxtool.db'),
  File "C:\Users\me\tools\HXTool-master\hxtool_db.py", line 36, in __init__
    self.check_schema()
  File "C:\Users\me\tools\HXTool-master\hxtool_db.py", line 52, in check_schema
    current_schema_version = self._db.table('schema_version').get(eid = 1)
```
Consequently, a user who does:
```
pip install -r requirements.txt
```
will get tinydb 4.0.0 (at the time of writing) and HXTool won't even start.

Until the project can be updated to support tinydb 4, I recommend having the `requirements.txt` insist upon 3.15.2.