### PR TITLE
Support for event-only IOCs in HXTool ES UI

### DIFF
--- a/hxtool_api.py
+++ b/hxtool_api.py
@@ -233,12 +233,14 @@ def hxtool_api_enterprise_search_new_db(hx_api_object):
 	#   <Context document="processEvent" search="processEvent/process" type="event" />
 	# to:
 	#   <Context document="eventItem" search="eventItem/processEvent/process" type="event" />
-	#
+    # This will not convert conditions such as:
+	#   <Context document="FileItem" search="FileItem/FullPath" type="endpoint" />
+
 	event_item_script = re.sub(
-		'<Context\s+document="(?!eventItem).+"\s+search="(?!eventItem/)(?P<search>.+)"\s+type="(?!mir).+"\s+/>',
-		'<Context document="eventItem" search="eventItem/\g<search>" type="event" />',
-		HXAPI.b64(ioc_script['ioc'], True).decode('utf-8'),
-		flags=re.IGNORECASE)
+	    '<Context\s+document="(?!eventItem).+"\s+search="(?!eventItem/)(?P<search>.+Event.+)"\s+type="(?!mir).+"\s+/>',
+	    '<Context document="eventItem" search="eventItem/\g<search>" type="event" />',
+	    HXAPI.b64(ioc_script['ioc'], True).decode('utf-8'),
+	    flags=re.IGNORECASE)
 
 	enterprise_search_task.add_step(enterprise_search_task_module, kwargs = {
 										'script' : HXAPI.b64(event_item_script),
@@ -283,7 +285,7 @@ def hxtool_api_enterprise_search_new_file(hx_api_object):
 
 	# see comment in hxtool_api_enterprise_search_new_db above
 	event_item_script = re.sub(
-		'<Context\s+document="(?!eventItem).+"\s+search="(?!eventItem/)(?P<search>.+)"\s+type="(?!mir).+"\s+/>',
+		'<Context\s+document="(?!eventItem).+"\s+search="(?!eventItem/)(?P<search>.+Event.+)"\s+type="(?!mir).+"\s+/>',
 		'<Context document="eventItem" search="eventItem/\g<search>" type="event" />',
 		ioc_script.decode('utf-8'),
 		flags=re.IGNORECASE)


### PR DESCRIPTION
Adds support to ES interface for OpenIOCs that do not use the "eventItem" prefix for real-time events. This enables OpenIOCs to be uploaded that contain conditions in the format required by the HX ES API:
`
<Context document="eventItem" search="eventItem/processEvent/process" type="event" />
`
As well as conditions that do not include the required eventItem prefix. This format is found in production IOC content shipped to HX via DTI, and also in IOCs available on the FireEye Market and looks like this:
`
<Context document="processEvent" search="processEvent/process" type="event" />
`
This change will not affect IOCs that reference terms unrelated to real-time events such as:
`
<Context document="FileItem" search="FileItem/FullPath" type="endpoint" />
`