### PR TITLE
Remove import to gunicorn.six

### DIFF
--- a/gunicorn_container.py
+++ b/gunicorn_container.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from gunicorn.app.base import Application
-from gunicorn.six import iteritems
 
 class GunicornContainerApplication(Application):
 	def __init__(self, app, options = {}):
@@ -11,9 +10,9 @@ class GunicornContainerApplication(Application):
 		super(GunicornContainerApplication, self).__init__()
 
 	def load_config(self):
-		config = dict([(key, value) for key, value in iteritems(self.options) 
+		config = dict([(key, value) for key, value in self.options.items() 
 						if key in self.cfg.settings and value is not None])
-		for key, value in iteritems(config):
+		for key, value in config.items():
 			self.cfg.set(key.lower(), value)
 				
 	def load(self):


### PR DESCRIPTION
gunicorn.six was removed with gunicorn v20 in https://github.com/benoitc/gunicorn/pull/2083.
Config files are small enough that copying the values in Py2 won't significantly impact performance.