### PR TITLE
Switch from pycryptodome to pycryptodomex

### DIFF
--- a/hxtool_util.py
+++ b/hxtool_util.py
@@ -17,14 +17,14 @@ except ImportError:
 	print("hxtool requires the 'Flask' module, please install it.")
 	exit(1)
 
-# pycryptodome imports
+# pycryptodomex imports
 try:
-	from Crypto.Cipher import AES
-	from Crypto.Protocol.KDF import PBKDF2
-	from Crypto.Hash import HMAC, SHA256
-	from Crypto.Util.Padding import pad, unpad
+	from Cryptodome.Cipher import AES
+	from Cryptodome.Protocol.KDF import PBKDF2
+	from Cryptodome.Hash import HMAC, SHA256
+	from Cryptodome.Util.Padding import pad, unpad
 except ImportError:
-	print("hxtool requires the 'pycryptodome' module, please install it.")
+	print("hxtool requires the 'pycryptodomex' module, please install it.")
 	exit(1)
 
 import hxtool_logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask>=0.11
 requests
-pycryptodome
+pycryptodomex
 tinydb>=3.15.2
 pandas
 keyring


### PR DESCRIPTION
Hello,
this proposal is on explicit switch from pycrypto/pycryptodome interface to pycryptodomex.
The pycrypto is old and years unmaintained - you probably know that as you have already switched to pycryptodome.
Currently used pycryptodome is its stand-in replacement - maintained and definitely better option, but problem is that in a distribution where pycrypto is used for something (like RedHat Enterprise Linux) the pycryptodome will be colliding with the namespace of the original pycrypto package.

I believe better option is to use explicitly the pycryptodomex with the new namespace Cryptodome - same author - same code-base, non-colliding python namespace.

You already guide users to install pycryptodome (as it will most probably not be in the linux distribution due to pyCrypto inheritance), so it won's make big difference to ask for pycryptodomex explicitly. Switching will have the benefit of users possibly already having the python3-pycryptodomex package in their distribution.

For more info on the topic I recommend:
Attempts to add pycryptodome to Fedora/EPEL/RHEL - rejected due to name collision:
- https://bugzilla.redhat.com/show_bug.cgi?id=1370919
- https://bugzilla.redhat.com/show_bug.cgi?id=1750765
- https://bugzilla.redhat.com/show_bug.cgi?id=1719957

Thank you
Michal Ambroz