### PR TITLE
Sorting of the rules

### DIFF
--- a/templates/ht_indicators.html
+++ b/templates/ht_indicators.html
@@ -39,7 +39,8 @@
 			ioc_datatable = $('#iocTable').DataTable( {
 				"ajax": "/api/v1/datatable_indicators",
 				"paging":   false,
-				"ordering": false,
+				"ordering": true,
+				"order": [[3,"asc"],[1,"asc"],[2,"desc"]],
 				"info":     false,
 				"searching": true,
 				"processing": false,


### PR DESCRIPTION
this patch allows sorting of the rules ... so user can click a column and sort it table by the column 

it also introduces the default sorting rule which groups the rules by  category and is alphabetical within the category.

If you create multiple clones of the same rule, you will see them in the list next to each other sorted by time.

![image](https://user-images.githubusercontent.com/723625/220482431-1aa426bb-b1c4-4d2a-b353-828a489ad0b0.png)
