### PR TITLE
Add support for url prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+data/hxtool.db
+*.pyc
+/log/*

--- a/data/conf.json
+++ b/data/conf.json
@@ -12,7 +12,8 @@
 		"ssl": "enabled",
 		"port": 8080,
 		"listen_address": "0.0.0.0",
-		"session_timeout": 30
+		"session_timeout": 30,
+		"url_prefix": "/hxtool"
 	},
 	"ssl": {
 		"cert": "hxtool.crt",

--- a/hxtool.py
+++ b/hxtool.py
@@ -715,8 +715,8 @@ if __name__ == "__main__":
 	# TODO: This should really be after app.run, but you cannot run code after app.run, so we'll leave this here for now.
 	logger.info("Application is running. Please point your browser to http{0}://{1}:{2}{3}. Press Ctrl+C/Ctrl+Break to exit.".format(
 																							's' if hxtool_global.hxtool_config['network']['ssl'] == 'enabled' else '',
-																							hxtool_global.hxtool_config['network']['listen_address'], 
-																							hxtool_global.hxtool_config['network']['port'], 
+																							hxtool_global.hxtool_config['network']['listen_address'],
+																							hxtool_global.hxtool_config['network']['port'],
 																							hxtool_global.hxtool_config['network']['url_prefix']))
 	if hxtool_global.hxtool_config['network']['ssl'] == "enabled":
 		app.config['SESSION_COOKIE_SECURE'] = True

--- a/hxtool.py
+++ b/hxtool.py
@@ -64,7 +64,6 @@ default_encoding = hxtool_vars.default_encoding
 hxtool_logging.setLoggerClass()
 logger = hxtool_logging.getLogger()
 
-
 hxtool_vars.app_instance_path = '.'
 oneoff_config = hxtool_config(combine_app_path(hxtool_vars.data_path, 'conf.json'))
 url_prefix = oneoff_config.get_config().get('network', {}).get('url_prefix', '')
@@ -77,7 +76,6 @@ ht_frontend = Blueprint('ht_frontend', __name__, template_folder='templates')
 
 # Register HXTool API blueprint
 app.register_blueprint(ht_api, url_prefix=url_prefix)
-
 
 ### Flask/Jinja Filters
 ####################################
@@ -115,7 +113,6 @@ def dashboardav(hx_api_object):
 @valid_session_required
 def dashboardagent(hx_api_object):
 	return render_template('ht_dashboard-agent.html', user=session['ht_user'], controller='{0}:{1}'.format(hx_api_object.hx_host, hx_api_object.hx_port))
-
 
 ### New host drilldown page
 @ht_frontend.route('/hostview', methods=['GET'])
@@ -578,7 +575,6 @@ def init_db():
 								apicache_refresh_interval = hxtool_global.hxtool_config.get_child_item('apicache', 'refresh_interval'),
 								write_cache_size = 0)
 
-
 def app_init(debug = False):	
 	# If we're debugging use a static key
 	if debug:
@@ -632,7 +628,6 @@ def app_init(debug = False):
 	#			logger.info("No background credential for {}, not starting apicache".format(profile['profile_id']))
 	print(app.url_map)
 	
-
 # Version specific upgrade code goes here
 def hxtool_upgrade():
 	files_to_move = ['hxtool.db', 'conf.json', 'hxtool.key', 'hxtool.crt']

--- a/hxtool_api.py
+++ b/hxtool_api.py
@@ -3408,7 +3408,7 @@ def profile_by_id(profile_id):
 # Stacking Results #
 ####################
 
-@ht_api.route('/api/v{0}/stacking/<stack_job_eid>/results'.format(HXTOOL_API_VERSION), methods=['GET'])
+@ht_api.route('/api/v{0}/stacking/results/<stack_job_eid>'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def stack_job_results(hx_api_object, stack_job_eid):
 	stack_job = hxtool_global.hxtool_db.stackJobGet(stack_job_eid = stack_job_eid)

--- a/hxtool_api.py
+++ b/hxtool_api.py
@@ -28,7 +28,6 @@ from hx_openioc import openioc_to_hxioc
 ht_api = Blueprint('ht_api', __name__, template_folder='templates')
 logger = hxtool_logging.getLogger(__name__)
 
-
 ###################################
 # Common User interface endpoints #
 ###################################
@@ -66,7 +65,6 @@ def hxtool_api_version_get(hx_api_object):
 	(ret, response_code, response_data) = hx_api_object.restGetControllerVersion()
 	(r, rcode) = create_api_response(ret, response_code, response_data)
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
-
 
 #################
 # Audit Manager #
@@ -129,7 +127,6 @@ def hxtool_api_auditmanager_remove(hx_api_object):
 		rmessage = "Audit action remove failed"
 
 	return(app.response_class(response=json.dumps(rmessage), status=rcode, mimetype='application/json'))
-
 
 #################
 # Audit viewer  #
@@ -200,7 +197,6 @@ def hxtool_api_auditviewer_query(hx_api_object):
 
 	return(app.response_class(response=json.dumps(response), status=200, mimetype='application/json'))
 
-
 ################
 # Acquisitions #
 ################
@@ -261,8 +257,6 @@ def hxtool_api_acquisition_new(hx_api_object):
 	app.logger.info(format_activity_log(msg="acquisition", action="new", host=request.args.get('id'), user=session['ht_user'], controller=session['hx_ip']))
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
 
-
-
 @ht_api.route('/api/v{0}/acquisition/file'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def hxtool_api_acquisition_file(hx_api_object):
@@ -304,7 +298,6 @@ def hxtool_api_acquisition_triage(hx_api_object):
 	(r, rcode) = create_api_response(ret, response_code, response_data)
 	app.logger.info(format_activity_log(msg="triage acquisition", action="new", host=request.args.get('id'), user=session['ht_user'], controller=session['hx_ip']))
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
-
 
 #####################
 # Enterprise Search #
@@ -433,7 +426,6 @@ def hxtool_api_enterprise_search_new_file(hx_api_object):
 	app.logger.info(format_activity_log(msg="enterprise search", action="new", user=session['ht_user'], controller=session['hx_ip']))
 	return(app.response_class(response=json.dumps("OK"), status=200, mimetype='application/json'))
 
-
 #########
 # Hosts #
 #########
@@ -490,7 +482,6 @@ def hxtool_api_hosts_remove(hx_api_object):
 	app.logger.info(format_activity_log(msg="host action", action="remove", id=request.args.get('id'), user=session['ht_user'], controller=session['hx_ip']))
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
 
-
 ###################
 # Manage OpenIOCs #
 ###################
@@ -533,7 +524,6 @@ def hxtool_api_openioc_download(hx_api_object):
 	app.logger.info(format_activity_log(msg="openioc action", action="download", name=myiocData['iocname'], user=session['ht_user'], controller=session['hx_ip']))
 	return send_file(buffer, download_name=myiocData['iocname'] + ".ioc", as_attachment=True)
 
-
 ##########
 # Alerts #
 ##########
@@ -569,7 +559,6 @@ def hxtool_api_alerts_get(hx_api_object):
 		(r, rcode) = create_api_response(ret, response_code, response_data)
 		return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))			
 
-
 #####################
 # Alert Annotations #
 #####################
@@ -588,11 +577,9 @@ def hxtool_api_annotation_alert_view(hx_api_object):
 	alertAnnotations = hxtool_global.hxtool_db.alertGet(session['ht_profileid'], request.args.get('id'))
 	return(app.response_class(response=json.dumps(alertAnnotations), status=200, mimetype='application/json'))
 
-
 #############
 # Scheduler #
 #############
-
 @ht_api.route('/api/v{0}/scheduler/remove'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def hxtool_api_scheduler_remove(hx_api_object):
@@ -639,11 +626,9 @@ def scheduler_tasks(hx_api_object):
 				})
 	return(app.response_class(response=json.dumps(mytasks), status=200, mimetype='application/json'))
 
-
 ################
 # Task profile #
 ################
-
 @ht_api.route('/api/v{0}/taskprofile/remove'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def hxtool_api_taskprofile_remove(hx_api_object):
@@ -660,7 +645,6 @@ def hxtool_api_taskprofile_new(hx_api_object):
 	(r, rcode) = create_api_response(ret=True)
 	app.logger.info(format_activity_log(msg="task profile action", action="new", name=mydata['name'], user=session['ht_user'], controller=session['hx_ip']))
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
-
 
 ###############
 # Host Groups #
@@ -691,11 +675,9 @@ def hxtool_api_hostgroup_id(hx_api_object, hostgroup_id):
 		logger.info(format_activity_log(msg="host group action", action="remove", hostgroup_id=hostgroup_id, user=session['ht_user'], controller=session['hx_ip']))
 		return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
 
-
 ####################
 # Bulk Acquisition #
 ####################
-
 # Remove
 @ht_api.route('/api/v{0}/acquisition/bulk/remove'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -759,7 +741,6 @@ def hxtool_api_acquisition_bulk_download(hx_api_object):
 		app.logger.warn(format_activity_log(msg="bulk acquisition action", action="download", error="No host entries were returned for bulk acquisition", id=request.args.get('id'), user=session['ht_user'], controller=session['hx_ip']))
 
 	return(app.response_class(response=json.dumps("OK"), status=200, mimetype='application/json'))
-
 
 # New bulk acquisiton from scriptstore
 @ht_api.route('/api/v{0}/acquisition/bulk/new/db'.format(HXTOOL_API_VERSION), methods=['GET'])
@@ -827,7 +808,6 @@ def hxtool_api_acquisition_bulk_new_file(hx_api_object):
 
 	return(app.response_class(response=json.dumps("OK"), status=200, mimetype='application/json'))
 
-
 ###########
 # Scripts #
 ###########
@@ -873,8 +853,6 @@ def hxtool_api_scripts_download(hx_api_object):
 
 	app.logger.info(format_activity_log(msg="script action", action="download", id=request.args.get('id'), user=session['ht_user'], controller=session['hx_ip']))
 	return send_file(buffer, download_name=myscriptData['scriptname'] + ".json", as_attachment=True)
-
-
 
 ########################
 # IOC Streaming API    #
@@ -1082,7 +1060,6 @@ def hxtool_api_streaming_indicators_export(hx_api_object):
 		return send_file(buffer, download_name=iocfname, as_attachment=True)
 	return('Nothing selected to export', 500)
 
-
 @ht_api.route('/api/v{0}/streaming_indicators/import'.format(HXTOOL_API_VERSION), methods=['POST'])
 @valid_session_required
 def hxtool_api_streaming_indicators_import(hx_api_object):
@@ -1185,7 +1162,6 @@ def hxtool_handle_streaming_indicator_import(hx_api_object, iocs):
 					app.logger.info(format_activity_log(msg="streaming rule action", reason="unable to import indicator", action="import", name=ioc['name'], user=session['ht_user'], controller=session['hx_ip']))
 	return					
 
-
 ########################
 # Indicator categories #
 ########################
@@ -1228,7 +1204,6 @@ def hxtool_api_indicator_category_new(hx_api_object):
 	app.logger.info(format_activity_log(msg="rule category action", action="new", name=request.args.get('name'), user=session['ht_user'], controller=session['hx_ip']))
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
 
-
 ##############
 # Conditions #
 ##############
@@ -1238,7 +1213,6 @@ def hxtool_api_conditions_get(hx_api_object):
 	(ret, response_code, response_data) = hx_api_object.restGetConditionDetails(request.args.get('id'))
 	(r, rcode) = create_api_response(ret, response_code, response_data)
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
-
 
 ###################
 # Indicator queue #
@@ -1282,7 +1256,6 @@ def hxtool_api_indicatorqueue_import(hx_api_object):
 		
 	return(app.response_class(response=json.dumps("OK"), status=200, mimetype='application/json'))
 
-
 ##############
 # Indicators #
 ##############
@@ -1293,7 +1266,6 @@ def hxtool_api_indicators_remove(hx_api_object):
 	(r, rcode) = create_api_response(ret, response_code, response_data)
 	app.logger.info(format_activity_log(msg="rule action", action="remove", name=request.args.get('url'), user=session['ht_user'], controller=session['hx_ip']))
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/indicators/get/conditions'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -1306,7 +1278,6 @@ def hxtool_api_indicators_get_conditions(hx_api_object):
 
 	(r, rcode) = create_api_response(ret, response_code, myconditions)
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/indicators/export'.format(HXTOOL_API_VERSION), methods=['POST'])
 @valid_session_required
@@ -1414,7 +1385,6 @@ def hxtool_api_indicators_import(hx_api_object):
 
 	return(app.response_class(response=json.dumps("OK"), status=200, mimetype='application/json'))
 
-
 @ht_api.route('/api/v{0}/indicators/new'.format(HXTOOL_API_VERSION), methods=['POST'])
 @valid_session_required
 def hxtool_api_indicators_new(hx_api_object):
@@ -1499,7 +1469,6 @@ def hxtool_api_indicators_new(hx_api_object):
 		app.logger.warn(format_activity_log(msg="rule action", action="new", reason="failed to create indicator", user=session['ht_user'], controller=session['hx_ip']))
 		return ('failed to create indicator', 500)
 
-
 @ht_api.route('/api/v{0}/indicators/edit'.format(HXTOOL_API_VERSION), methods=['POST'])
 @valid_session_required
 def hxtool_api_indicators_edit(hx_api_object):
@@ -1549,11 +1518,9 @@ def hxtool_api_indicators_edit(hx_api_object):
 		# Failed to create indicator
 		return('failed to create indicator',500)
 
-
 #################################
 # Custom configuration channels #
 #################################
-
 @ht_api.route('/api/v{0}/ccc/new'.format(HXTOOL_API_VERSION), methods=['POST'])
 @valid_session_required
 def hxtool_api_ccc_new(hx_api_object):
@@ -1586,7 +1553,6 @@ def hxtool_api_ccc_get(hx_api_object):
 	(ret, response_code, response_data) = hx_api_object.restGetConfigChannelConfiguration(request.args.get('id'))
 	(r, rcode) = create_api_response(ret, response_code, response_data)
 	return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
-
 
 ############
 # Stacking #
@@ -1648,12 +1614,9 @@ def hxtool_api_stacking_stop(hx_api_object):
 		app.logger.info(format_activity_log(msg="stacking", action="stop", id=request.args.get('id'), user=session['ht_user'], controller=session['hx_ip']))
 		return(app.response_class(response=json.dumps(r), status=rcode, mimetype='application/json'))
 
-
-
 ##########################
 # Multi-file acquisition #
 ##########################
-
 @ht_api.route('/api/v{0}/acquisition/multi/file_listing/new'.format(HXTOOL_API_VERSION), methods=['POST'])
 @valid_session_required
 def hxtool_api_acquisition_multi_file_listing(hx_api_object):
@@ -1719,7 +1682,6 @@ def hxtool_api_acquisition_multi_file_listing(hx_api_object):
 	app.logger.info(format_activity_log(msg="multi-file listing acquisition", action="new", hostset_id=hostset, user=session['ht_user'], controller=session['hx_ip']))
 	return(app.response_class(response=json.dumps("OK"), status=200, mimetype='application/json'))
 
-
 @ht_api.route('/api/v{0}/acquisition/multi/file_listing/stop'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def hxtool_api_acquisition_multi_file_listing_stop(hx_api_object):
@@ -1736,7 +1698,6 @@ def hxtool_api_acquisition_multi_file_listing_stop(hx_api_object):
 			return(app.response_class(response=json.dumps(response_data), status=response_code, mimetype='application/json'))
 	return(app.response_class(response=json.dumps("File listing job not found."), status=404, mimetype='application/json'))
 
-
 @ht_api.route('/api/v{0}/acquisition/multi/file_listing/remove'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def hxtool_api_acquisition_multi_file_listing_remove(hx_api_object):
@@ -1749,7 +1710,6 @@ def hxtool_api_acquisition_multi_file_listing_remove(hx_api_object):
 		hxtool_global.hxtool_db.fileListingDelete(file_listing_job.doc_id)
 		app.logger.info(format_activity_log(msg="multi-file listing acquisition", action="remove", id=request.args.get('id'), user=session['ht_user'], controller=session['hx_ip']))
 		return(app.response_class(response=json.dumps("OK"), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/acquisition/multi/mf/stop'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -1783,7 +1743,6 @@ def hxtool_api_acquisition_multi_mf_remove(hx_api_object):
 			hxtool_global.hxtool_db.multiFileDelete(mf_job.doc_id)
 			app.logger.info(format_activity_log(msg="multi-file acquisition", action="remove", id=mf_job.doc_id, user=session['ht_user'], controller=session['hx_ip']))
 			return(app.response_class(response=json.dumps("OK"), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/acquisition/multi/mf/new'.format(HXTOOL_API_VERSION), methods=['POST'])
 @valid_session_required
@@ -1861,7 +1820,6 @@ def hxtool_api_acquisition_multi_mf_new(hx_api_object):
 ##############
 # Datatables #
 ##############
-
 @ht_api.route('/api/v{0}/datatable_multi_filelisting'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def datatable_multi_filelisting(hx_api_object):
@@ -1891,7 +1849,6 @@ def datatable_multi_filelisting(hx_api_object):
 		job['DT_RowId'] = job['id']
 		data_rows.append(job)
 	return(app.response_class(response=json.dumps({'data': data_rows}), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/datatable_multi_multifile'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -1948,8 +1905,6 @@ def datatable_stacking(hx_api_object):
 
 	return(app.response_class(response=json.dumps(mydata), status=200, mimetype='application/json'))
 
-
-
 @ht_api.route('/api/v{0}/datatable_ccc'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def datatable_ccc(hx_api_object):
@@ -1975,7 +1930,6 @@ def datatable_ccc(hx_api_object):
 				})
 
 	return(app.response_class(response=json.dumps(mydata), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/datatable/agentstatus/csv'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2016,7 +1970,6 @@ def datatable_agentstatus_csv(hx_api_object):
 
 	return send_file(mem, download_name="agent_statistics_" + myField + ".csv", as_attachment=True)
 
-
 @ht_api.route('/api/v{0}/datatable/agentstatus'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def datatable_agentstatus(hx_api_object):
@@ -2044,8 +1997,6 @@ def datatable_agentstatus(hx_api_object):
 				})
 
 	return(app.response_class(response=json.dumps(mydata), status=200, mimetype='application/json'))
-
-
 
 @ht_api.route('/api/v{0}/datatable/avcontent'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2076,7 +2027,6 @@ def datatable_avcontent_detail(hx_api_object):
 	del hresponse_data
 
 	return(app.response_class(response=json.dumps(mydata), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/datatable/avengine'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2160,7 +2110,6 @@ def datatable_categories(hx_api_object):
 
 	return(app.response_class(response=json.dumps(mydata), status=200, mimetype='application/json'))
 
-
 @ht_api.route('/api/v{0}/datatable_indicators'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def datatable_indicators(hx_api_object):
@@ -2187,7 +2136,6 @@ def datatable_indicators(hx_api_object):
 
 	return(app.response_class(response=json.dumps(mydata), status=200, mimetype='application/json'))
 
-
 @ht_api.route('/api/v{0}/datatable_hosts'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def datatable_hosts(hx_api_object):
@@ -2210,7 +2158,6 @@ def datatable_hosts(hx_api_object):
 				})
 
 	return(app.response_class(response=json.dumps(mydata), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/datatable_hosts_with_alerts'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2266,7 +2213,6 @@ def datatable_alerts_host(hx_api_object):
 
 		return(app.response_class(response=json.dumps(myalerts), status=200, mimetype='application/json'))
 
-
 @ht_api.route('/api/v{0}/datatable_alerts'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def datatable_alerts(hx_api_object):
@@ -2316,7 +2262,6 @@ def datatable_alerts(hx_api_object):
 			return('', 500)
 
 		return(app.response_class(response=json.dumps(myalerts), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/datatable_alerts_full'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2512,7 +2457,6 @@ def datatable_alerts_full(hx_api_object):
 
 		return(app.response_class(response=json.dumps(myalerts), status=200, mimetype='application/json'))
 
-
 @ht_api.route('/api/v{0}/datatable_scripts'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def datatable_scripts(hx_api_object):
@@ -2534,7 +2478,6 @@ def datatable_taskprofiles(hx_api_object):
 		mytaskprofiles = hxtool_global.hxtool_db.taskProfileList()
 		# TODO: filter passwords and keys in task params
 		return(app.response_class(response=json.dumps(mytaskprofiles), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/datatable_acqs'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2582,7 +2525,6 @@ def datatable_acqs(hx_api_object):
 								"action": acq['acq']['_id']
 							})
 				return(app.response_class(response=json.dumps(myacqs), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/datatable_acqs_host'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2673,7 +2615,6 @@ def datatable_indicatorqueue(hx_api_object):
 			"action" : indicator['id'],
 			})
 	return(app.response_class(response=json.dumps(myrules), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/datatable_bulk'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2780,8 +2721,6 @@ def datatable_bulk(hx_api_object):
 	else:
 		return('HX API Call failed',500)
 
-
-
 @ht_api.route('/api/v{0}/datatable_es_result_types'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def datatable_es_result_types(hx_api_object):
@@ -2808,7 +2747,6 @@ def datatable_es_result_types(hx_api_object):
 			return('HX API Call failed', 500)
 	else:
 		return('Missing search id', 404)
-
 
 @ht_api.route('/api/v{0}/datatable_es_result'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2837,11 +2775,9 @@ def datatable_es_result(hx_api_object):
 	else:
 		return('Missing search id or type', 404)
 
-
 ###########
 # ChartJS #
 ###########
-
 @ht_api.route('/api/v{0}/chartjs_agentstatus'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def chartjs_agentstatus(hx_api_object):
@@ -2878,8 +2814,6 @@ def chartjs_agentstatus(hx_api_object):
 			})
 
 	return(app.response_class(response=json.dumps(rData), status=200, mimetype='application/json'))
-
-
 
 @ht_api.route('/api/v{0}/chartjs_malwarecontent'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -2938,7 +2872,6 @@ def chartjs_malwarecontent(hx_api_object):
 
 		return(app.response_class(response=json.dumps(myData), status=200, mimetype='application/json'))
 
-
 @ht_api.route('/api/v{0}/chartjs_malwareengine'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def chartjs_malwareengine(hx_api_object):
@@ -2993,7 +2926,6 @@ def chartjs_malwareengine(hx_api_object):
 			})
 
 		return(app.response_class(response=json.dumps(myData), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/chartjs_malwarestatus'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -3097,7 +3029,6 @@ def hxtool_api_enterprise_search_chartjs_searches(hx_api_object):
 	else:
 		return('HX API Call failed',500)
 
-
 @ht_api.route('/api/v{0}/acquisition/bulk/chartjs_acquisitions'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def hxtool_api_acquisition_bulk_chartjs_acquisitions(hx_api_object):
@@ -3141,7 +3072,6 @@ def hxtool_api_acquisition_bulk_chartjs_acquisitions(hx_api_object):
 		return(app.response_class(response=json.dumps(myr), status=rcode, mimetype='application/json'))
 	else:
 		return('HX API Call failed',500)
-
 
 @ht_api.route('/api/v{0}/chartjs_hosts_initial_agent_checkin'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -3188,7 +3118,6 @@ def chartjs_hosts_initial_agent_checkin(hx_api_object):
 		return('', 500)
 
 	return(app.response_class(response=json.dumps(myhosts), status=200, mimetype='application/json'))
-
 
 @ht_api.route('/api/v{0}/chartjs_events_timeline'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -3243,7 +3172,6 @@ def chartjs_events_timeline(hx_api_object):
 	else:
 		return('',500)
 
-
 @ht_api.route('/api/v{0}/chartjs_host_alert_timeline'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def chartjs_host_alert_timeline(hx_api_object):
@@ -3277,7 +3205,6 @@ def chartjs_host_alert_timeline(hx_api_object):
 		return(app.response_class(response=json.dumps(mydates), status=200, mimetype='application/json'))
 	else:
 		return('',500)
-
 
 @ht_api.route('/api/v{0}/chartjs_events_distribution'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -3313,7 +3240,6 @@ def chartjs_events_distribution(hx_api_object):
 		return(app.response_class(response=json.dumps(mydata), status=200, mimetype='application/json'))
 	else:
 		return('',500)
-
 
 @ht_api.route('/api/v{0}/chartjs_inactive_hosts_per_hostset'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
@@ -3362,11 +3288,9 @@ def chartjs_inactive_hosts_per_hostset(hx_api_object):
 	else:
 		return('',500)
 
-
 ######################
 # Profile Management #
 ######################
-
 @ht_api.route('/api/v{0}/profile'.format(HXTOOL_API_VERSION), methods=['GET', 'PUT'])
 def profile():
 	if request.method == 'GET':
@@ -3403,11 +3327,9 @@ def profile_by_id(profile_id):
 		else:
 			return make_response_by_code(404)
 
-
 ####################
 # Stacking Results #
 ####################
-
 @ht_api.route('/api/v{0}/stacking/results/<stack_job_eid>'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def stack_job_results(hx_api_object, stack_job_eid):
@@ -3421,7 +3343,6 @@ def stack_job_results(hx_api_object, stack_job_eid):
 		
 	ht_data_model = hxtool_data_models(stack_job['stack_type'])
 	return ht_data_model.stack_data(stack_job['results'])	
-
 
 #####################
 # Cache API calls ###
@@ -3452,11 +3373,9 @@ def cache_statistics(hx_api_object):
 	else:
 		return(app.response_class(response=json.dumps("DISABLED"), status=200, mimetype='application/json'))
 
-
 #######################
 ### X15 INTEGRATION ###
 #######################
-
 @ht_api.route('/api/v{0}/analysis/data'.format(HXTOOL_API_VERSION), methods=['GET'])
 @valid_session_required
 def x15_analysis_data(hx_api_object):
@@ -3514,8 +3433,6 @@ def x15_analysis_auditdata(hx_api_object):
 		return make_response_by_code(400)
 
 #######################
-
-
 def create_api_response(ret = True, response_code = 200, response_data = False):
 
 	api_response = {}

--- a/hxtool_config.py
+++ b/hxtool_config.py
@@ -29,7 +29,8 @@ class hxtool_config:
 			'ssl' : 'enabled',
 			'port' : 8080,
 			'listen_address' : '0.0.0.0',
-			'session_timeout' : 30
+			'session_timeout' : 30,
+			'url_prefix' : '',
 		},
 		'ssl' : {
 			'cert' : 'hxtool.crt',

--- a/static/hxtool-css/hxtool-main.css
+++ b/static/hxtool-css/hxtool-main.css
@@ -1,14 +1,14 @@
-@import url("/static/hxtool-css/hxtool-grid.css");
-@import url("/static/hxtool-css/hxtool-top-nav.css");
-@import url("/static/hxtool-css/hxtool-table.css");
-@import url("/static/hxtool-css/hxtool-panel.css");
-@import url("/static/hxtool-css/hxtool-datatables.css");
-@import url("/static/hxtool-css/hxtool-typography.css");
-@import url("/static/hxtool-css/hxtool-chartjs.css");
-@import url("/static/hxtool-css/hxtool-scriptbuilder.css");
-@import url("/static/hxtool-css/hxtool-login.css");
-@import url("/static/hxtool-css/hxtool-host.css");
-@import url("/static/hxtool-css/hxtool-rtioc.css");
+@import url("./hxtool-grid.css");
+@import url("./hxtool-top-nav.css");
+@import url("./hxtool-table.css");
+@import url("./hxtool-panel.css");
+@import url("./hxtool-datatables.css");
+@import url("./hxtool-typography.css");
+@import url("./hxtool-chartjs.css");
+@import url("./hxtool-scriptbuilder.css");
+@import url("./hxtool-login.css");
+@import url("./hxtool-host.css");
+@import url("./hxtool-rtioc.css");
 
 body {
 	background: radial-gradient(62vw at 50% 0%, #355881 0%, #222222 100%);

--- a/static/hxtool-js/hxtool-doc-ready.js
+++ b/static/hxtool-js/hxtool-doc-ready.js
@@ -5,7 +5,7 @@ function collapse_all_dropdowns() {
 	});
 }
 
-function hxtool_doc_ready() { 
+function hxtool_doc_ready(uri_hostsearch, uri_logout) { 
 
 	/* Global stuff */
 
@@ -66,7 +66,7 @@ function hxtool_doc_ready() {
 	$("#hxtool_global_search").keypress(function (e) {
 		var key = e.which;
 		if(key == 13) {
-			location.href = "/hostsearch?q=" + $("#hxtool_global_search").val();
+			location.href = uri_hostsearch + $("#hxtool_global_search").val();
 		}
 	});
 
@@ -76,7 +76,7 @@ function hxtool_doc_ready() {
 	});
 
 	$("#hxtoolLogout").click(function(e) {
-		window.location.href = "/logout"
+		window.location.href = uri_logout
 		e.stopPropagation();
 	});
 

--- a/static/js/datatables_parser.js
+++ b/static/js/datatables_parser.js
@@ -1,6 +1,6 @@
-function datatables_parseHostlink(data) {
+function datatables_parseHostlink(data, link='') {
 	myArr = data.split("___");
-	data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(myArr[1]) + '">' + myArr[0] + '</a>';
+	data = '<a class="hostLink" href="' + link +'?host=' + encodeURIComponent(myArr[1]) + '">' + myArr[0] + '</a>';
 	return(data);
 }
 

--- a/templates/ht_acqs.html
+++ b/templates/ht_acqs.html
@@ -8,7 +8,7 @@
 	$(document).ready(function() {
 
 		var acq_datatable = $('#acqTable').DataTable( {
-			"ajax": "/api/v1/datatable_acqs",
+			"ajax": "{{ url_for('ht_api.datatable_acqs') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -44,7 +44,7 @@
 				{
 				 "targets": 1,
 				 render: function ( data, type, row, meta ) {
-				 	return(datatables_parseHostlink(data));
+				 	return(datatables_parseHostlink(data, "{{ url_for('ht_frontend.host_view') }}"));
 				 }
 				},
 				{
@@ -88,15 +88,15 @@
 				 render: function ( data, type, row, meta ) {
 				 	if(type === 'display'){
 				 		if (row.type == "triage" && row.state == "COMPLETE") {
-				 			data = "<button style='margin-right: 6px;' data-type='download' data-id='/api/v1/acquisition/download?id=/hx/api/v3/acqs/triages/" + row.DT_RowId + ".mans' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main'> download <i class='fe-icon--right fas fa-download'></i></button>";
+				 			data = "<button style='margin-right: 6px;' data-type='download' data-id='{{ url_for('ht_api.hxtool_api_acquisition_download') }}?id=/hx/api/v3/acqs/triages/" + row.DT_RowId + ".mans' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main'> download <i class='fe-icon--right fas fa-download'></i></button>";
 				 			data += "<button data-type='remove' data-id='acqs/triages/" + row.DT_RowId + "' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main-remove'> remove <i class='fe-icon--right fas fa-ban'></i></button>";
 				 		}
 				 		else if (row.type == "live" && row.state == "COMPLETE") {
-				 			data = "<button style='margin-right: 6px;' data-type='download' data-id='/api/v1/acquisition/download?id=/hx/api/v3/acqs/live/" + row.DT_RowId + ".mans&content=json' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main'> download <i class='fe-icon--right fas fa-download'></i></button>";
+				 			data = "<button style='margin-right: 6px;' data-type='download' data-id='{{ url_for('ht_api.hxtool_api_acquisition_download') }}?id=/hx/api/v3/acqs/live/" + row.DT_RowId + ".mans&content=json' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main'> download <i class='fe-icon--right fas fa-download'></i></button>";
 				 			data += "<button data-type='remove' data-id='acqs/live/" + row.DT_RowId + "' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main-remove'> remove <i class='fe-icon--right fas fa-ban'></i></button>";
 				 		}
 				 		else if (row.type == "file" && row.state == "COMPLETE") {
-				 			data = "<button style='margin-right: 6px;' data-type='download' data-id='/api/v1/acquisition/download?id=/hx/api/v3/acqs/files/" + row.DT_RowId + ".zip' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main'> download <i class='fe-icon--right fas fa-download'></i></button>";
+				 			data = "<button style='margin-right: 6px;' data-type='download' data-id='{{ url_for('ht_api.hxtool_api_acquisition_download') }}?id=/hx/api/v3/acqs/files/" + row.DT_RowId + ".zip' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main'> download <i class='fe-icon--right fas fa-download'></i></button>";
 				 			data += "<button data-type='remove' data-id='acqs/files/" + row.DT_RowId + "' class='acqAction fe-btn fe-btn--sm fe-btn--hxtool-main-remove'> remove <i class='fe-icon--right fas fa-ban'></i></button>";
 				 		}
 				 		else {
@@ -117,9 +117,10 @@
 				location.href = $(this).data("id");
 			}
 			else if ($(this).data("type") == "remove") {
-				hxtool_ajax_get_request("/api/v1/acquisition/remove", "url=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_remove') }}", "url=" + $(this).data("id"), function() {
 					myrow.fadeOut(200, function() {
 						acq_datatable.row(myrow).remove().draw();
+						
 					});
 				});
 			}

--- a/templates/ht_alert.html
+++ b/templates/ht_alert.html
@@ -45,7 +45,7 @@
 			if (e.which == 13) {
 				$('#shader').show();
 				urltail = parseFilters()
-				alert_datatable.ajax.url( '/api/v1/datatable_alerts_full?limit=1000&startDate=' + $("#from").val() + '&endDate=' + $("#to").val() + urltail ).load(function ( json ) {
+				alert_datatable.ajax.url( '{{ url_for('ht_api.datatable_alerts_full') }}?limit=1000&startDate=' + $("#from").val() + '&endDate=' + $("#to").val() + urltail ).load(function ( json ) {
 					$('#shader').hide();
 				});
 			}
@@ -55,7 +55,7 @@
 			if (e.which == 13) {
 				$('#shader').show();
 				urltail = parseFilters()
-				alert_datatable.ajax.url( '/api/v1/datatable_alerts_full?limit=1000&startDate=' + $("#from").val() + '&endDate=' + $("#to").val() + urltail ).load(function ( json ) {
+				alert_datatable.ajax.url( '{{ url_for('ht_api.datatable_alerts_full') }}?limit=1000&startDate=' + $("#from").val() + '&endDate=' + $("#to").val() + urltail ).load(function ( json ) {
 					$('#shader').hide();
 				});
 			}
@@ -65,7 +65,7 @@
 			if (e.which == 13) {
 				$('#shader').show();
 				urltail = parseFilters()
-				alert_datatable.ajax.url( '/api/v1/datatable_alerts_full?limit=1000&startDate=' + $("#from").val() + '&endDate=' + $("#to").val() + urltail ).load(function ( json ) {
+				alert_datatable.ajax.url( '{{ url_for('ht_api.datatable_alerts_full') }}?limit=1000&startDate=' + $("#from").val() + '&endDate=' + $("#to").val() + urltail ).load(function ( json ) {
 					$('#shader').hide();
 				});
 			}
@@ -74,7 +74,7 @@
 		$("#refresh").click(function() {
 			// $('#hxtool_shader').show();
 			urltail = parseFilters()
-			alert_datatable.ajax.url( '/api/v1/datatable_alerts_full?limit=1000&startDate=' + $("#from").val() + '&endDate=' + $("#to").val() + urltail ).load(function ( json ) {
+			alert_datatable.ajax.url( '{{ url_for('ht_api.datatable_alerts_full') }}?limit=1000&startDate=' + $("#from").val() + '&endDate=' + $("#to").val() + urltail ).load(function ( json ) {
 				kaka = "kaka";
 				// $('#hxtool_shader').hide();
 			});
@@ -91,7 +91,7 @@
 		$(document).on('click', '.showannotation', function() {
 			aArr = $(this).attr("id").split("_");
 
-			hxtool_ajax_get_request("/api/v1/annotation/alert/view", "id=" + aArr[1], function(myAnnotations) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_annotation_alert_view') }}", "id=" + aArr[1], function(myAnnotations) {
 
 				$("#annotateViewText").html("");
 
@@ -160,7 +160,7 @@
 			data.append("text", $("#annotateText").val());
 			data.append("state", $("#annotationState").data("id"));
 
-			hxtool_ajax_post_request("/api/v1/annotation/add", data, function() {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_annotation_add') }}", data, function() {
 				$("#annotationPopup").hide();
 				alert_datatable.ajax.reload();
 			});
@@ -177,7 +177,7 @@
 
 		$("#alertTable").on("click", ".alertAction", function(){
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/alerts/" + $(this).data("type"), "id=" + $(this).data("id"), function() {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_alerts_get') }}" + $(this).data("type"), "id=" + $(this).data("id"), function() {
 				myrow.fadeOut(200, function() {
 					alert_datatable.row(myrow).remove().draw();
 				})
@@ -187,7 +187,7 @@
 
 		$.fn.dataTable.ext.errMode = 'none';
 		alert_datatable = $('#alertTable').DataTable( {
-			"ajax": "/api/v1/datatable_alerts_full?limit=1000&startDate=" + pastDate + "&endDate=" + currentDate,
+			"ajax": "{{ url_for('ht_api.datatable_alerts_full') }}?limit=1000&startDate=" + pastDate + "&endDate=" + currentDate,
 			"paging":   false,
 			"ordering": true,
 			"colReorder": true,
@@ -233,7 +233,7 @@
 				 "width": "150px",
 				 render: function ( data, type, row, meta ) {
 					myArr = data.split("___");
-					data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(myArr[1]) + '&alertid=' + encodeURIComponent(myArr[2]) + '">' + myArr[0] + '</a>';
+					data = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + encodeURIComponent(myArr[1]) + '&alertid=' + encodeURIComponent(myArr[2]) + '">' + myArr[0] + '</a>';
 					return(data);
 				 }
 				},
@@ -324,7 +324,7 @@
 		var currentDate = fullDate.toISOString().substr(0, 10);
 
 		var jsonData = $.ajax({
-			url: "/api/v1/chartjs_events_timeline?startDate=" + pastDate + "&endDate=" + currentDate,
+			url: "{{ url_for('ht_api.chartjs_events_timeline') }}?startDate=" + pastDate + "&endDate=" + currentDate,
 			dataType: 'json',
 		}).done(function (myChartData) {
 

--- a/templates/ht_auditmanager.html
+++ b/templates/ht_auditmanager.html
@@ -7,7 +7,7 @@
 	$(document).ready(function() {
 
 		var auditTable = $('#auditTable').DataTable( {
-			"ajax": "/api/v1/auditmanager/getaudits",
+			"ajax": "{{ url_for('ht_api.hxtool_api_auditmanager_getaudits') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -65,10 +65,10 @@
 			myrow = $(this).closest("tr");
 
 			if (mytype == "explore") {
-				location.href = "/auditexplorer?id=" + $(this).data("id");
+				location.href = "{{ url_for('ht_frontend.auditexplorer') }}?id=" + $(this).data("id");
 			}
 			else if (mytype == "remove") {
-				hxtool_ajax_get_request("/api/v1/auditmanager/remove", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_auditmanager_remove') }}", "id=" + $(this).data("id"), function() {
 					myrow.fadeOut(200, function() {
 						auditTable.row(myrow).remove().draw();
 					});

--- a/templates/ht_auditviewer.html
+++ b/templates/ht_auditviewer.html
@@ -11,7 +11,7 @@
 		$('#result_icon').addClass("fa-spinner");
 		$('#result_icon').addClass("fa-spin");
 
-		$.getJSON('/api/v1/auditviewer/query?q=' + query, function(myResponse) {
+		$.getJSON('{{ url_for('ht_api.hxtool_api_auditviewer_query') }}?q=' + query, function(myResponse) {
 
 			$('#result_icon').removeClass("fa-spin");
 			$('#result_icon').removeClass("fa-spinner");

--- a/templates/ht_bulkacq.html
+++ b/templates/ht_bulkacq.html
@@ -16,7 +16,7 @@
 
 		$.fn.dataTable.ext.errMode = 'none';
 		var bulk_datatable = $('#bulktable').DataTable( {
-			"ajax": "/api/v1/datatable_bulk",
+			"ajax": "{{ url_for('ht_api.datatable_bulk') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -191,10 +191,10 @@
 
 		$("#bulktable").on("click", ".bulkLink", function(){
 			if ($(this).data("type") == "stacking") {
-				location.href = "/stacking";
+				location.href = "{{ url_for('ht_frontend.stacking') }}";
 			}
 			else if ($(this).data("type") == "multi") {
-				location.href = "/multifile";
+				location.href = "{{ url_for('ht_frontend.multifile') }}";
 			}			
 		});
 
@@ -224,15 +224,22 @@
 		}).on('mouseleave','.bulkname',  function(){
 			$(this).next().hide();
 		});
+		
+		const urlmap = new Map();
+		urlmap.set('remove', '{{ url_for('ht_api.hxtool_api_acquisition_bulk_remove') }}')
+		urlmap.set('stop', '{{ url_for('ht_api.hxtool_api_acquisition_bulk_stop') }}')
+		urlmap.set('stopdownload', '{{ url_for('ht_api.hxtool_api_acquisition_bulk_stopdownload') }}')
+		urlmap.set('download', '{{ url_for('ht_api.hxtool_api_acquisition_bulk_download') }}')
 
 		$("#bulktable").on("click", ".bulkAction", function(){
 			mytype = $(this).data("type");
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/acquisition/bulk/" + $(this).data("type"), "id=" + $(this).data("id"), function() {
+
+			hxtool_ajax_get_request(urlmap.get($(this).data("type")), "id=" + $(this).data("id"), function() {
 				if (mytype == "remove") {
 					myrow.fadeOut(200, function() {
 						bulk_datatable.row(myrow).remove().draw();
-						updateChartJS(chartjs_searches, "/api/v1/acquisition/bulk/chartjs_acquisitions?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
+						updateChartJS(chartjs_searches, "{{ url_for('ht_api.hxtool_api_acquisition_bulk_chartjs_acquisitions') }}?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
 					})
 				}
 				else {
@@ -267,11 +274,11 @@
 
 				// Set the endpoint and IOC Data
 				if (mymode == "hxtool") {
-					myApiEndpoint = "/api/v1/acquisition/bulk/new/db";
+					myApiEndpoint = "{{ url_for('ht_api.hxtool_api_acquisition_bulk_new_db') }}";
 					data.append("bulkscript", $("#bulkScriptDb").data("id"));
 				}
 				else if (mymode == "file") {
-					myApiEndpoint = "/api/v1/acquisition/bulk/new/file";
+					myApiEndpoint = "{{ url_for('ht_api.hxtool_api_acquisition_bulk_new_file') }}";
 					$.each($('#bulkscript').prop('files'), function(key, value) {
 						data.append("bulkscript", value);
 					});
@@ -314,11 +321,11 @@
 										$(this).progressNoAnimate();
 									});
 								});
-								updateChartJS(chartjs_searches, "/api/v1/acquisition/bulk/chartjs_acquisitions?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
+								updateChartJS(chartjs_searches, "{{ url_for('ht_api.hxtool_api_acquisition_bulk_chartjs_acquisitions') }}?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
 							}, 1000 );
 						}
 						else {
-							location.href = "/scheduler";
+							location.href = "{{ url_for('ht_frontend.scheduler_view') }}";
 						}
 					});
 				}
@@ -334,11 +341,11 @@
 										$(this).progressNoAnimate();
 									});
 								});
-								updateChartJS(chartjs_searches, "/api/v1/acquisition/bulk/chartjs_acquisitions?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
+								updateChartJS(chartjs_searches, "{{ url_for('ht_api.hxtool_api_acquisition_bulk_chartjs_acquisitions') }}?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
 							}, 1000 );
 						}
 						else {
-							location.href = "/scheduler";
+							location.href = "{{ url_for('ht_frontend.scheduler_view') }}";
 						}
 					});
 				}
@@ -353,7 +360,7 @@
 
 		// ChartJS: Historical searches
 		var jsonData = $.ajax({
-			url: "/api/v1/acquisition/bulk/chartjs_acquisitions?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate,
+			url: "{{ url_for('ht_api.hxtool_api_acquisition_bulk_chartjs_acquisitions') }}?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate,
 			dataType: 'json',
 		}).done(function (myChartData) {
 

--- a/templates/ht_categories.html
+++ b/templates/ht_categories.html
@@ -7,7 +7,7 @@
 	$(document).ready(function() {
 
 		var category_datatable = $('#categoryTable').DataTable( {
-			"ajax": "/api/v1/datatable_categories",
+			"ajax": "{{ url_for('ht_api.datatable_categories') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -52,7 +52,7 @@
 
 		$('#categoryTable').on("click", ".categoryRemove", function(){
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/indicator_category/remove", "id=" + $(this).data("id"), function() {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicator_category_remove') }}", "id=" + $(this).data("id"), function() {
 					myrow.fadeOut(200, function() {
 						category_datatable.row(myrow).remove().draw();
 					});
@@ -61,7 +61,7 @@
 
 		$('#categoryNewSubmit').click(function(){
 			$('#categoryNewPopup').hide();
-			hxtool_ajax_get_request("/api/v1/indicator_category/new", "name=" + $("#category_name").val() + "&retention_policy=" + $("#retention_policy").data("id") + "&edit_policy=" + $("#edit_policy").data("id"), function() {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicator_category_new') }}", "name=" + $("#category_name").val() + "&retention_policy=" + $("#retention_policy").data("id") + "&edit_policy=" + $("#edit_policy").data("id"), function() {
 				category_datatable.ajax.reload();
 			});
 		});

--- a/templates/ht_configchannel.html
+++ b/templates/ht_configchannel.html
@@ -7,7 +7,7 @@
 	$(document).ready(function() {
 
 		var ccc_datatable = $('#cccTable').DataTable( {
-			"ajax": "/api/v1/datatable_ccc",
+			"ajax": "{{ url_for('ht_api.datatable_ccc') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -53,14 +53,14 @@
 		$("#cccTable").on("click", ".cccAction", function() {
 			if ($(this).data("type") == "remove") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/ccc/remove", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_ccc_remove') }}", "id=" + $(this).data("id"), function() {
 					myrow.fadeOut(200, function() {
 						ccc_datatable.row(myrow).remove().draw();
 					});
 				});
 			}
 			if ($(this).data("type") == "view") {
-				hxtool_ajax_get_request("/api/v1/ccc/get", "id=" + $(this).data("id"), function(cccResponse) {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_ccc_get') }}", "id=" + $(this).data("id"), function(cccResponse) {
 					mytemp = JSON.parse(cccResponse['api_response']);
 					myPrettyJSON = JSON.stringify(mytemp, undefined, 4);
 
@@ -106,7 +106,7 @@
 			var requestdata = new FormData();
 			requestdata.append("channel", JSON.stringify(myChannel));
 
-			hxtool_ajax_post_request("/api/v1/ccc/new", requestdata, function() {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_ccc_new') }}", requestdata, function() {
 				ccc_datatable.ajax.reload();
 			});			
 			

--- a/templates/ht_dashboard-agent.html
+++ b/templates/ht_dashboard-agent.html
@@ -34,10 +34,10 @@
 					tfield = field;
 				}
 
-				$(".csvButton").data("url", "/api/v1/datatable/agentstatus/csv?pattern=" + label + "&field=" + tfield);
+				$(".csvButton").data("url", "{{ url_for('ht_api.datatable_agentstatus_csv') }}?pattern=" + label + "&field=" + tfield);
 
 				agentContentPopup_datatable = $('#agentContentTable').DataTable( {
-					"ajax": "/api/v1/datatable/agentstatus?pattern=" + label + "&field=" + tfield,
+					"ajax": "{{ url_for('ht_api.datatable_agentstatus') }}?pattern=" + label + "&field=" + tfield,
 					"paging":   false,
 					"ordering": false,
 					"info":     false,
@@ -57,7 +57,7 @@
 						{
 						 "targets": 0,
 						 render: function ( data, type, row, meta ) {
-							data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(row.DT_RowId) + '">' + data + '</a>';
+							data = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + encodeURIComponent(row.DT_RowId) + '">' + data + '</a>';
 							return(data);
 						 }
 						},
@@ -79,7 +79,7 @@
 
 			// ChartJS - Agent version
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_agentstatus?field=agent_version",
+				url: "{{ url_for('ht_api.chartjs_agentstatus') }}?field=agent_version",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -114,7 +114,7 @@
 
 			// ChartJS - Domain
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_agentstatus?field=domain",
+				url: "{{ url_for('ht_api.chartjs_agentstatus') }}?field=domain",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -149,7 +149,7 @@
 
 			// ChartJS - Timezone
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_agentstatus?field=timezone",
+				url: "{{ url_for('ht_api.chartjs_agentstatus') }}?field=timezone",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -184,7 +184,7 @@
 
 			// ChartJS - containenment state
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_agentstatus?field=containment_state",
+				url: "{{ url_for('ht_api.chartjs_agentstatus') }}?field=containment_state",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -219,7 +219,7 @@
 
 			// ChartJS - Containment queued
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_agentstatus?field=containment_queued",
+				url: "{{ url_for('ht_api.chartjs_agentstatus') }}?field=containment_queued",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -254,7 +254,7 @@
 
 			// ChartJS - containment software missing
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_agentstatus?field=containment_missing_software",
+				url: "{{ url_for('ht_api.chartjs_agentstatus') }}?field=containment_missing_software",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -289,7 +289,7 @@
 
 			// ChartJS - Reported clone
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_agentstatus?field=reported_clone",
+				url: "{{ url_for('ht_api.chartjs_agentstatus') }}?field=reported_clone",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -324,7 +324,7 @@
 
 			// ChartJS - OS product
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_agentstatus?field=os.product_name",
+				url: "{{ url_for('ht_api.chartjs_agentstatus') }}?field=os.product_name",
 				dataType: 'json',
 			}).done(function (myChartData) {
 

--- a/templates/ht_dashboard-av.html
+++ b/templates/ht_dashboard-av.html
@@ -7,7 +7,7 @@
 		function datatable_last_alerts() {
 			$.fn.dataTable.ext.errMode = 'none';
 			var row2_cell1_datatable = $('#row2_cell1_table').DataTable( {
-				"ajax": "/api/v1/datatable_alerts?limit=20&source=MAL",
+				"ajax": "{{ url_for('ht_api.datatable_alerts') }}?limit=20&source=MAL",
 				"paging":   false,
 				"ordering": false,
 				"info":     false,
@@ -33,7 +33,7 @@
 					 render: function ( data, type, row, meta ) {
 					 	if(type === 'display'){
 					 		myArr = data.split("___");
-					 		data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(myArr[1]) + '&alertid=' + encodeURIComponent(myArr[2]) + '">' + myArr[0] + '</a>';
+					 		data = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + encodeURIComponent(myArr[1]) + '&alertid=' + encodeURIComponent(myArr[2]) + '">' + myArr[0] + '</a>';
 					 	}
 					 	return data;
 					 }
@@ -66,7 +66,7 @@
 
 				$("#avContentPopup").find(".fe-modal__header").find("h4").append("<i id='popupSpinner' style='margin-left: 12px; color: #11a962;' class='fas fa-spinner fa-spin'></i>");
 				avContentPopup_datatable.clear().draw();
-				avContentPopup_datatable.ajax.url("/api/v1/datatable/avcontent?version=" + label);
+				avContentPopup_datatable.ajax.url("{{ url_for('ht_api.datatable_avcontent_detail') }}?version=" + label);
 				avContentPopup_datatable.ajax.reload(function() {
 					$("#popupSpinner").remove();
 				});
@@ -84,7 +84,7 @@
 
 				$("#avEnginePopup").find(".fe-modal__header").find("h4").append("<i id='popupSpinner' style='margin-left: 12px; color: #11a962;' class='fas fa-spinner fa-spin'></i>");
 				avEnginePopup_datatable.clear().draw();
-				avEnginePopup_datatable.ajax.url("/api/v1/datatable/avengine?version=" + label);
+				avEnginePopup_datatable.ajax.url("{{ url_for('ht_api.datatable_avengine_detail') }}?version=" + label);
 				avEnginePopup_datatable.ajax.reload(function() {
 					$("#popupSpinner").remove();
 				});
@@ -102,7 +102,7 @@
 
 				$("#avStatusPopup").find(".fe-modal__header").find("h4").append("<i id='popupSpinner' style='margin-left: 12px; color: #11a962;' class='fas fa-spinner fa-spin'></i>");
 				avStatusPopup_datatable.clear().draw();
-				avStatusPopup_datatable.ajax.url("/api/v1/datatable/avstatus?state=" + label);
+				avStatusPopup_datatable.ajax.url("{{ url_for('ht_api.datatable_avstatus_detail') }}?state=" + label);
 				avStatusPopup_datatable.ajax.reload(function() {
 					$("#popupSpinner").remove();
 				});
@@ -154,7 +154,7 @@
 					{
 					 "targets": 0,
 					 render: function ( data, type, row, meta ) {
-						data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(row.agentid) + '">' + data + '</a>';
+						data = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + encodeURIComponent(row.agentid) + '">' + data + '</a>';
 						return(data);
 					 }
 					},
@@ -184,7 +184,7 @@
 					{
 					 "targets": 0,
 					 render: function ( data, type, row, meta ) {
-						data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(row.agentid) + '">' + data + '</a>';
+						data = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + encodeURIComponent(row.agentid) + '">' + data + '</a>';
 						return(data);
 					 }
 					},
@@ -214,7 +214,7 @@
 					{
 					 "targets": 0,
 					 render: function ( data, type, row, meta ) {
-						data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(row.agentid) + '">' + data + '</a>';
+						data = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + encodeURIComponent(row.agentid) + '">' + data + '</a>';
 						return(data);
 					 }
 					},
@@ -224,7 +224,7 @@
 
 
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_malwarecontent",
+				url: "{{ url_for('ht_api.chartjs_malwarecontent') }}",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -258,7 +258,7 @@
 			});
 
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_malwareengine",
+				url: "{{ url_for('ht_api.chartjs_malwareengine') }}",
 				dataType: 'json',
 			}).done(function (myChartData) {
 
@@ -293,7 +293,7 @@
 
 
 			var jsonData = $.ajax({
-				url: "/api/v1/chartjs_malwarestatus",
+				url: "{{ url_for('ht_api.chartjs_malwarestatus') }}",
 				dataType: 'json',
 			}).done(function (myChartData) {
 

--- a/templates/ht_file_listing.html
+++ b/templates/ht_file_listing.html
@@ -108,7 +108,7 @@
 		});
 
 		$("#backButton").click(function() {
-			location.href = "/multifile";
+			location.href = "{{ url_for('ht_frontend.multifile') }}";
 		});
 
 	});
@@ -119,7 +119,7 @@
 	<button class="fe-btn fe-btn--md fe-btn--hxtool-main-master" id="backButton"> back <i style='color: #11a962;' class="fe-icon--right fas fa-arrow-left"></i></button>
 {{ htPanelNoHeader.widgetFooter() }}
 
-<form id="form_file_download" action="/api/v1/acquisition/multi/mf/new" method="POST">
+<form id="form_file_download" action="{{ url_for('ht_api.hxtool_api_acquisition_multi_mf_new') }}" method="POST">
 	<div id='two-pane-page'>
 		<div id='floating-pane-left'>
 			{{ htPanel.widgetHeader("File listing", panelId="flistTableContainer", panelIcon="fa-table") }}

--- a/templates/ht_host_view.html
+++ b/templates/ht_host_view.html
@@ -279,7 +279,7 @@
 	}
 
 	function setContainmentInfo(myAgentId) {
-		hxtool_ajax_get_request("/api/v1/hosts/get", "id=" + myAgentId, function(myhost) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hosts_get') }}", "id=" + myAgentId, function(myhost) {
 			var myhostinfo = JSON.parse(myhost['api_response']);
 
 			$("#fieldContainment").html(myhostinfo['data']['containment_state']);
@@ -324,7 +324,7 @@
 		// Alerts table
 		$.fn.dataTable.ext.errMode = 'none';
 		var hostAlert_datatable = $('#hostAlertTable').DataTable( {
-			"ajax": "/api/v1/datatable_alerts_host?limit=1000&host=" + myAgentId,
+			"ajax": "{{ url_for('ht_api.datatable_alerts_host') }}?limit=1000&host=" + myAgentId,
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -354,7 +354,7 @@
 		// Acqs table
 		$.fn.dataTable.ext.errMode = 'none';
 		var hostAcq_datatable = $('#hostAcqTable').DataTable( {
-			"ajax": "/api/v1/datatable_acqs_host?host=" + myAgentId,
+			"ajax": "{{ url_for('ht_api.datatable_acqs_host') }}?host=" + myAgentId,
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -383,7 +383,7 @@
 		});
 
 		// Get hostinfo
-		hxtool_ajax_get_request("/api/v1/hosts/get", "id=" + myAgentId, function(myhost) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hosts_get') }}", "id=" + myAgentId, function(myhost) {
 			myhostinfo = JSON.parse(myhost['api_response']);
 
 			$("#product").html(host_parsePlatform(myhostinfo['data']['os']['platform']));
@@ -411,13 +411,13 @@
 		}, 20 * 1000);
 
 		// Get configuration
-		hxtool_ajax_get_request("/api/v1/hosts/config", "id=" + myAgentId, function(myhost) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hosts_config') }}", "id=" + myAgentId, function(myhost) {
 			myconf = JSON.parse(myhost['api_response']);
 			$("#showConfigPopup").find(".fe-modal__body").append(generateNestedTable(myconf));
 		});
 
 		// Get sysinfo
-		hxtool_ajax_get_request("/api/v1/hosts/sysinfo", "id=" + myAgentId, function(myhost) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hosts_sysinfo') }}", "id=" + myAgentId, function(myhost) {
 			mysysinfo = JSON.parse(myhost['api_response']);
 
 			$("#fieldDrives").html(mysysinfo['data']['drives']);
@@ -474,17 +474,17 @@
 			var myMode = $("#containButton").html();
 
 			if (myMode == "contain") {
-				hxtool_ajax_get_request("/api/v1/hosts/contain", "id=" + myAgentId, function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hosts_contain') }}", "id=" + myAgentId, function() {
 					setContainmentInfo(myAgentId);
 				});
 			}
 			else if (myMode == "uncontain") {
-				hxtool_ajax_get_request("/api/v1/hosts/uncontain", "id=" + myAgentId, function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hosts_uncontain') }}", "id=" + myAgentId, function() {
 					setContainmentInfo(myAgentId);
 				});
 			}
 			else if (myMode == "approve containment") {
-				hxtool_ajax_get_request("/api/v1/hosts/contain/approve", "id=" + myAgentId, function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hosts/contain_approve') }}", "id=" + myAgentId, function() {
 					setContainmentInfo(myAgentId);
 				});
 			}
@@ -505,7 +505,7 @@
 			var myAcqMode = $("input[name='datasource']:checked").val();
 
 			if (myAcqMode == "hxtool") {
-				hxtool_ajax_get_request("/api/v1/acquisition/new", "id=" + myAgentId + "&scriptid=" + $("#dataScriptDb").data("id") + "&scriptname=" + $("#dataname").val(), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_new') }}", "id=" + myAgentId + "&scriptid=" + $("#dataScriptDb").data("id") + "&scriptname=" + $("#dataname").val(), function() {
 					hostAcq_datatable.ajax.reload();
 				});
 			}
@@ -518,7 +518,7 @@
 				data.append("id", myAgentId);
 				data.append("scriptname", $("#dataname").val());
 
-				hxtool_ajax_post_request("/api/v1/acquisition/new", data, function(data) {
+				hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_acquisition_new') }}", data, function(data) {
 					hostAcq_datatable.ajax.reload();
 				});
 			}
@@ -535,7 +535,7 @@
 
 		$("#fileSubmit").click(function() {
 			$("#fileNewPopup").hide();
-			hxtool_ajax_get_request("/api/v1/acquisition/file", "id=" + myAgentId + "&type=" + $("#filemode").data("id") + "&path=" + $("#filepath").val() + "&filename=" + $("#filename").val(), function() {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_file') }}", "id=" + myAgentId + "&type=" + $("#filemode").data("id") + "&path=" + $("#filepath").val() + "&filename=" + $("#filename").val(), function() {
 				hostAcq_datatable.ajax.reload();
 			});
 
@@ -570,12 +570,12 @@
 			myTriageMode = $("input[name='triagemode']:checked").val();
 
 			if (myTriageMode == "standard" || myTriageMode in [1,2,4,8]) {
-				hxtool_ajax_get_request("/api/v1/acquisition/triage", "&id=" + myAgentId + "&type=" + myTriageMode, function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_triage') }}", "&id=" + myAgentId + "&type=" + myTriageMode, function() {
 					hostAcq_datatable.ajax.reload();
 				});
 			}
 			else if (myTriageMode == "timestamp") {
-				hxtool_ajax_get_request("/api/v1/acquisition/triage", "&id=" + myAgentId + "&type=" + myTriageMode + "&timestamp=" + $("#triage_timestamp").val(), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_triage') }}", "&id=" + myAgentId + "&type=" + myTriageMode + "&timestamp=" + $("#triage_timestamp").val(), function() {
 					hostAcq_datatable.ajax.reload();
 				});
 			}
@@ -595,14 +595,14 @@
 			var myAgentID = (myhostinfo['data']['_id']);
 			var myFilePath = $(this).data("id");
 
-			hxtool_ajax_get_request("/api/v1/acquisition/file", "id=" + myAgentID + "&type=api&filepath=" + myFilePath, function(resp) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_file') }}", "id=" + myAgentID + "&type=api&filepath=" + myFilePath, function(resp) {
 				hostAcq_datatable.ajax.reload();
 			});
 
 		});
 
 		$('#hostAlertTable').on('click','tr',function(){
-			hxtool_ajax_get_request("/api/v1/alerts/get", "id=" + $(this).attr("id"), function(myalert) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_alerts_get') }}", "id=" + $(this).attr("id"), function(myalert) {
 
 				var alert = JSON.parse(myalert['api_response']);
 
@@ -623,7 +623,7 @@
 
 		$('#hostAcqTable').on('click','tr',function() {
 			myUrl = $(this).attr("id");
-			hxtool_ajax_get_request("/api/v1/acquisition/get", "url=" + $(this).attr("id"), function(myacq) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_get') }}", "url=" + $(this).attr("id"), function(myacq) {
 				var acq = JSON.parse(myacq['api_response']);
 
 				// First clear the content panel
@@ -651,19 +651,19 @@
 		
 		$('#hostContentPanel').on('click','.acqDownload',function() {
 			if ($(this).data("type") == "files" || $(this).data("type") == "bulk") {
-				location.href = "/api/v1/acquisition/download?id=" + $(this).data("id") + ".zip";
+				location.href = "{{ url_for('ht_api.hxtool_api_acquisition_download') }}?id=" + $(this).data("id") + ".zip";
 			}
 			else if ($(this).data("type") == "live") {
-				location.href = "/api/v1/acquisition/download?id=" + $(this).data("id") + ".mans&content=json";
+				location.href = "{{ url_for('ht_api.hxtool_api_acquisition_download') }}?id=" + $(this).data("id") + ".mans&content=json";
 			}
 			else {
-				location.href = "/api/v1/acquisition/download?id=" + $(this).data("id") + ".mans";
+				location.href = "{{ url_for('ht_api.hxtool_api_acquisition_download') }}?id=" + $(this).data("id") + ".mans";
 			}
 		});
 
 		$('#hostContentPanel').on('click','.acqRemove',function() {
 			myrowUrl = $(this).data("id");
-			hxtool_ajax_get_request("/api/v1/acquisition/remove", "url=" + $(this).data("id"), function(resMyRemove) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_remove') }}", "url=" + $(this).data("id"), function(resMyRemove) {
 				$("#hostContentPanel").find(".panelContentClass").html("");
 				hostAcq_datatable.row("#/hx/api/v3/" + myrowUrl).remove().draw();
 			});
@@ -671,7 +671,7 @@
 
 		$('#hostContentPanel').on('click','.alertRemove',function() {
 			myrowID = $(this).data("id");
-			hxtool_ajax_get_request("/api/v1/alerts/remove", "id=" + $(this).data("id"), function(resMyRemove) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_alerts_remove') }}", "id=" + $(this).data("id"), function(resMyRemove) {
 				$("#hostContentPanel").find(".panelContentClass").html("");
 				hostAlert_datatable.row("#" + myrowID).remove().draw();
 			});

--- a/templates/ht_hostsearch.html
+++ b/templates/ht_hostsearch.html
@@ -9,7 +9,7 @@
 
 		$.fn.dataTable.ext.errMode = 'none';
 		var host_datatable = $('#hostTable').DataTable( {
-			"ajax": "/api/v1/datatable_hosts?q=" + query,
+			"ajax": "{{ url_for('ht_api.datatable_hosts') }}?q=" + query,
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -35,7 +35,7 @@
 				{
 				 "targets": 0,
 				 render: function ( data, type, row, meta ) {
-					mydata = '<a class="hostLink" href="/hostview?host=' + row.DT_RowId + '">' + data + '</a>';
+					mydata = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + row.DT_RowId + '">' + data + '</a>';
 				 	return (mydata);
 				 }
 				},
@@ -60,7 +60,17 @@
 
 		$("#hostTable").on("click", ".hostAction", function(){
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/hosts/" + $(this).data("type"), "id=" + $(this).data("id"), function() {
+			
+			const urlMap = new Map();
+			map1.set('config', '{{ url_for('ht_api.hxtool_api_hosts_config') }}');
+			map1.set('get', '{{ url_for('ht_api.hxtool_api_hosts_get') }}');
+			map1.set('sysinfo', '{{ url_for('ht_api.hxtool_api_hosts_sysinfo') }}');
+			map1.set('contain', '{{ url_for('ht_api.hxtool_api_hosts_contain') }}');
+			map1.set('uncontain', '{{ url_for('ht_api.hxtool_api_hosts_uncontain') }}');
+			map1.set('contain/approve', '{{ url_for('ht_api.hxtool_api_hosts_contain_approve') }}');
+			map1.set('remove', '{{ url_for('ht_api.hxtool_api_hosts_remove') }}');
+
+			hxtool_ajax_get_request(urlMap.get($(this).data("type")), "id=" + $(this).data("id"), function() {
 				myrow.fadeOut(200, function() {
 					host_datatable.row(myrow).remove().draw();
 				})

--- a/templates/ht_indicator_create_edit.html
+++ b/templates/ht_indicator_create_edit.html
@@ -211,7 +211,7 @@
 			{% endif %}
 
 			// Render categories
-			hxtool_ajax_get_request("/api/v1/indicator_category/list", "", function(setResponse) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicator_category_list') }}", "", function(setResponse) {
 				myCategoryResponse = JSON.parse(setResponse['api_response']);
 				mycats = [];
 				$.each(myCategoryResponse['data']['entries'], function( index, value ) {
@@ -349,8 +349,8 @@
 						var myForm = new FormData();
 						myForm.append("rule", JSON.stringify(data));
 
-						hxtool_ajax_post_request("/api/v1/indicators/new", myForm, function() {
-							location.href = "/indicators";
+						hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_indicators_new') }}", myForm, function() {
+							location.href = "{{ url_for('ht_frontend.indicators') }}";
 						});
 
 					}
@@ -365,8 +365,8 @@
 						var myForm = new FormData();
 						myForm.append("rule", JSON.stringify(data));
 
-						hxtool_ajax_post_request("/api/v1/indicators/edit", myForm, function() {
-							location.href = "/indicators";
+						hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_indicators_edit') }}", myForm, function() {
+							location.href = "{{ url_for('ht_frontend.indicators') }}";
 						});
 					}
 					else {

--- a/templates/ht_indicatorqueue.html
+++ b/templates/ht_indicatorqueue.html
@@ -33,11 +33,11 @@
 
 	$(document).ready(function() {
 
-		hxtool_ajax_get_request("/api/v1/indicator_category/get_edit_policies", "", function(myCategoryPolicies) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_streaming_indicator_category_get_edit_policies') }}", "", function(myCategoryPolicies) {
 			myEditPolicies = JSON.parse(myCategoryPolicies['api_response']);
 
 			ioc_datatable = $('#iocTable').DataTable( {
-				"ajax": "/api/v1/datatable_indicatorqueue",
+				"ajax": "{{ url_for('ht_api.datatable_indicatorqueue') }}",
 				"paging":   false,
 				"ordering": false,
 				"info":     false,
@@ -160,28 +160,28 @@
 
 			if ($(this).data("type") == "approve") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/indicatorqueue/approve", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicatorqueue_approve') }}", "id=" + $(this).data("id"), function() {
 					ioc_datatable.ajax.reload();
 				});
 			}
 
 			if ($(this).data("type") == "deny") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/indicatorqueue/deny", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicatorqueue_deny') }}", "id=" + $(this).data("id"), function() {
 					ioc_datatable.ajax.reload();
 				});
 			}
 
 			if ($(this).data("type") == "remove") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/indicatorqueue/remove", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicatorqueue_remove') }}", "id=" + $(this).data("id"), function() {
 					myrow.fadeOut(200, function() {
 						ioc_datatable.row(myrow).remove().draw();
 					});
 				});
 			}
 			if ($(this).data("type") == "view") {
-				hxtool_ajax_get_request("/api/v1/indicatorqueue/view", "id=" + $(this).data("id"), function(myRule) {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicatorqueue_view') }}", "id=" + $(this).data("id"), function(myRule) {
 					
 					// First empty the container
 					$("#ruleViewPopup").find(".fe-modal__body").html("");
@@ -225,7 +225,7 @@
 				data.append("ruleImport", value);
 			});
 
-			hxtool_ajax_post_request("/api/v1/indicatorqueue/import", data, function() {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_indicatorqueue_import') }}", data, function() {
 				ioc_datatable.ajax.reload();
 			});
 
@@ -246,7 +246,7 @@
 				}
 
 			});
-			location.href = "/api/v1/indicators/export?indicators=" + JSON.stringify(myExports);
+			location.href = "{{ url_for('ht_api.hxtool_api_indicators_export') }}?indicators=" + JSON.stringify(myExports);
 		});
 	
 	});

--- a/templates/ht_indicators.html
+++ b/templates/ht_indicators.html
@@ -33,11 +33,11 @@
 
 	$(document).ready(function() {
 
-		hxtool_ajax_get_request("/api/v1/indicator_category/get_edit_policies", "", function(myCategoryPolicies) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicator_category_get_edit_policies') }}", "", function(myCategoryPolicies) {
 			myEditPolicies = JSON.parse(myCategoryPolicies['api_response']);
 
 			ioc_datatable = $('#iocTable').DataTable( {
-				"ajax": "/api/v1/datatable_indicators",
+				"ajax": "{{ url_for('ht_api.datatable_indicators') }}",
 				"paging":   false,
 				"ordering": true,
 				"order": [[3,"asc"],[1,"asc"],[2,"desc"]],
@@ -110,7 +110,7 @@
 			$('div.dataTables_filter input').addClass("fe-input");
 			
 			// Render categories
-			hxtool_ajax_get_request("/api/v1/indicator_category/list", "", function(setResponse) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicator_category_list') }}", "", function(setResponse) {
 				myCategoryResponse = JSON.parse(setResponse['api_response']);
 				mycats = [];
 				$.each(myCategoryResponse['data']['entries'], function( index, value ) {
@@ -129,21 +129,21 @@
 
 		$("#iocTable").on("click", ".iocAction", function() {
 			if ($(this).data("type") == "edit") {
-				location.href = "/rtioc?indicator=" + encodeURIComponent($(this).data("url"));
+				location.href = "{{ url_for('ht_frontend.rtioc') }}?indicator=" + encodeURIComponent($(this).data("url"));
 			}
 			if ($(this).data("type") == "clone") {
-				location.href = "/rtioc?indicator=" + encodeURIComponent($(this).data("url")) + "&clone=true";
+				location.href = "{{ url_for('ht_frontend.rtioc') }}?indicator=" + encodeURIComponent($(this).data("url")) + "&clone=true";
 			}
 			if ($(this).data("type") == "remove") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/indicators/remove", "url=" + encodeURIComponent($(this).data("url")), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicators_remove') }}", "url=" + encodeURIComponent($(this).data("url")), function() {
 					myrow.fadeOut(200, function() {
 						ioc_datatable.row(myrow).remove().draw();
 					});
 				});
 			}
 			if ($(this).data("type") == "view") {
-				hxtool_ajax_get_request("/api/v1/indicators/get/conditions", "uuid=" + $(this).data("id") + "&url=" + encodeURIComponent($(this).data("url")), function(myConditionsResponse) {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicators_get_conditions') }}", "uuid=" + $(this).data("id") + "&url=" + encodeURIComponent($(this).data("url")), function(myConditionsResponse) {
 					myConditions = JSON.parse(myConditionsResponse['api_response']);
 
 					// First empty the container
@@ -188,7 +188,7 @@
 			data.append('category', $('#ruleImportCategory').data("id"));
 			data.append('platform', $('#ruleImportPlatform').data("id"));
 			
-			hxtool_ajax_post_request("/api/v1/indicators/import", data, function() {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_indicators_import') }}", data, function() {
 				ioc_datatable.ajax.reload();
 			});
 
@@ -213,7 +213,7 @@
 			$.ajax
 			({
 				type: 'POST',
-				url: '/api/v1/indicators/export',
+				url: '{{ url_for('ht_api.hxtool_api_indicators_export') }}',
 				contentType: 'application/json',
 				xhrFields: { responseType: 'blob' },
 				processData: false,
@@ -242,7 +242,7 @@
 		});
 
 		$("#createButton").click(function() {
-			location.href = "/rtioc";
+			location.href = "{{ url_for('ht_frontend.rtioc') }}";
 		});
 		
 	});

--- a/templates/ht_login.html
+++ b/templates/ht_login.html
@@ -9,18 +9,18 @@
 <head>
 	<title>HXTool - Please Authenticate</title>
 	<script type="text/javascript" src="{{ url_for('static', filename='js/jquery-3.6.0.min.js') }}"></script>
-	<script type="text/javascript" src="/static/hxtool-js/hxtool-generic.js"></script>
-	<script type="text/javascript" src="/static/hxtool-js/hxtool-doc-ready.js"></script>
-	<link href="/static/fontawesome-free-5.7.2-web/css/all.css" rel="stylesheet">
-	<link href="/static/fe-fds/fds-dark.css" rel="stylesheet" />
-	<link rel="stylesheet" type="text/css" href="static/hxtool-css/hxtool-main.css">
-	<link href="/static/favicon.ico" rel="icon" type="image/x-icon" />
+	<script type="text/javascript" src="{{ url_for('static', filename='hxtool-js/hxtool-generic.js') }}"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='hxtool-js/hxtool-doc-ready.js') }}"></script>
+	<link href="{{ url_for('static', filename='fontawesome-free-5.7.2-web/css/all.css') }}" rel="stylesheet">
+	<link href="{{ url_for('static', filename='fe-fds/fds-dark.css') }}" rel="stylesheet" />
+	<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='hxtool-css/hxtool-main.css') }}">
+	<link href="{{ url_for('static', filename='favicon.ico') }}" rel="icon" type="image/x-icon" />
 </head>
 
 <script language="JavaScript">
 
 	function getProfiles() {
-		hxtool_ajax_get_request("/api/v1/profile", "", function(myprofiles) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.profile') }}", "", function(myprofiles) {
 			$("#profile").next("div").find("ul").html("");
 			$.each(myprofiles.data, function() {
 				$("#profile").next("div").find("ul").append("<li class='fe-dropdown__item'><a class='fe-dropdown__item-link'><span class='fe-dropdown__item-link-left-section'><i style='margin-top: 2px;' class='fas fa-check fa-lg'></i></span><span class='fe-dropdown__item-link-text' data-id='" + this.profile_id + "'>" + this.hx_name + "</span></a></li>");
@@ -32,7 +32,10 @@
 	
 	$(document).ready(function() {
 		getProfiles();
-		hxtool_doc_ready();
+		hxtool_doc_ready(
+			'{{ url_for('ht_frontend.hosts') }}',
+			'{{ url_for('ht_frontend.logout') }}'
+		);
 
 		$(".hxtool_dynamic-dropdown").on( "click", "a", function(e) {
 			e.preventDefault();
@@ -51,7 +54,7 @@
 
 		$("#profile_delete").click(function() {
 			$("#profileRemove").find(".fe-modal__body").html("");
-			hxtool_ajax_get_request("/api/v1/profile", "", function(myprofiles) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.profile') }}", "", function(myprofiles) {
 				$("#profileRemove").find(".fe-modal__body").append("<table style='width: 100%;' class='hxtool_table'></table>");
 				$("#profileRemove").find(".fe-modal__body").find("table").append("<thead><th>name</th><th>hostname</th><th>port</th><th>action</th></thead>");
 				$("#profileRemove").find(".fe-modal__body").find("table").append("<tbody></tbody>");
@@ -69,7 +72,7 @@
 
 			$.ajax({
 				type: "DELETE",
-				url: "/api/v1/profile/" + profile_id,
+				url: "{{ url_for('ht_api.profile') }}" + profile_id,
 				contentType: "application/json; charset=utf-8",
 				dataType: "json",
 				success: function(r) {
@@ -107,7 +110,7 @@
 			
 			$.ajax({
 				type: "PUT",
-				url: "/api/v1/profile",
+				url: "{{ url_for('ht_api.profile') }}",
 				contentType: "application/json; charset=utf-8",
 				dataType: "json",
 				data: request_json,
@@ -135,7 +138,7 @@
 
 		<div style='padding: 24px;'>
 
-			<div style='text-align: center;'><img src='/static/fireeye-2-color.png' style='width: 250px;'></div>
+			<div style='text-align: center;'><img src='{{ url_for('static', filename='fireeye-2-color.png') }}' style='width: 250px;'></div>
 			<h3 style='text-align: center; font-size: 24px; font-weight: bold;'>HXTool {{ version }}</h3>
 			<h3 style='text-align: center; font-size: 14px;'>Extended user interface for FireEye Endpoint Security</h3>
 			<br/>

--- a/templates/ht_main-dashboard.html
+++ b/templates/ht_main-dashboard.html
@@ -5,10 +5,10 @@
 <script>
 
 	function refreshEverything(currentDate, row1_cell3_datatable, row2_cell1_datatable) {
-		updateChartJS(chartjs_ap, "/api/v1/chartjs_hosts_initial_agent_checkin?startDate=" + getHistoricDate($("#row1_cell2_select").data("id")) + "&endDate=" + currentDate);
-		updateChartJS(chartjs_ih, "/api/v1/chartjs_inactive_hosts_per_hostset?seconds=" + $("#row1_cell1_select").data("id"));
-		updateChartJS(chartjs_ad, "/api/v1/chartjs_events_distribution?startDate=" + getHistoricDate($("#row2_cell2_select").data("id")) + "&endDate=" + currentDate);
-		updateChartJS(chartjs_et, "/api/v1/chartjs_events_timeline?startDate=" + $("#row3_cell1_from").val() + "&endDate=" + $("#row3_cell1_to").val());
+		updateChartJS(chartjs_ap, "{{ url_for('ht_api.chartjs_hosts_initial_agent_checkin') }}?startDate=" + getHistoricDate($("#row1_cell2_select").data("id")) + "&endDate=" + currentDate);
+		updateChartJS(chartjs_ih, "{{ url_for('ht_api.chartjs_inactive_hosts_per_hostset') }}?seconds=" + $("#row1_cell1_select").data("id"));
+		updateChartJS(chartjs_ad, "{{ url_for('ht_api.chartjs_events_distribution') }}?startDate=" + getHistoricDate($("#row2_cell2_select").data("id")) + "&endDate=" + currentDate);
+		updateChartJS(chartjs_et, "{{ url_for('ht_api.chartjs_events_timeline') }}?startDate=" + $("#row3_cell1_from").val() + "&endDate=" + $("#row3_cell1_to").val());
 		row1_cell3_datatable.ajax.reload();
 		row2_cell1_datatable.ajax.reload();
 	}
@@ -40,15 +40,15 @@
 
 		// When the user changes graph settings
 		$(".row1_cell2-item").click(function() {
-			updateChartJS(chartjs_ap, "/api/v1/chartjs_hosts_initial_agent_checkin?startDate=" + getHistoricDate($(this).find("span").next().data("id")) + "&endDate=" + currentDate);
+			updateChartJS(chartjs_ap, "{{ url_for('ht_api.chartjs_hosts_initial_agent_checkin') }}?startDate=" + getHistoricDate($(this).find("span").next().data("id")) + "&endDate=" + currentDate);
 		});
 
 		$(".row1_cell1-item").click(function() {
-			updateChartJS(chartjs_ih, "/api/v1/chartjs_inactive_hosts_per_hostset?seconds=" + $(this).find("span").next().data("id"));
+			updateChartJS(chartjs_ih, "{{ url_for('ht_api.chartjs_inactive_hosts_per_hostset') }}?seconds=" + $(this).find("span").next().data("id"));
 		});
 
 		$(".row2_cell2-item").click(function() {
-			updateChartJS(chartjs_ad, "/api/v1/chartjs_events_distribution?startDate=" + getHistoricDate($(this).find("span").next().data("id")) + "&endDate=" + currentDate);
+			updateChartJS(chartjs_ad, "{{ url_for('ht_api.chartjs_events_distribution') }}?startDate=" + getHistoricDate($(this).find("span").next().data("id")) + "&endDate=" + currentDate);
 		});
 
 		$("button[id^='row3_cell1_nav_']").click(function() {
@@ -60,13 +60,13 @@
 		});
 
 		$("#row3_cell1_refresh").click(function() {
-			updateChartJS(chartjs_et, "/api/v1/chartjs_events_timeline?startDate=" + $("#row3_cell1_from").val() + "&endDate=" + $("#row3_cell1_to").val());
+			updateChartJS(chartjs_et, "{{ url_for('ht_api.chartjs_events_timeline') }}?startDate=" + $("#row3_cell1_from").val() + "&endDate=" + $("#row3_cell1_to").val());
 		});
 
 		// START: Charts
 		// ChartJS: Agent provisioning status
 		var jsonData = $.ajax({
-			url: "/api/v1/chartjs_hosts_initial_agent_checkin?startDate=" + getHistoricDate($("#row1_cell2_select").data("id")) + "&endDate=" + currentDate,
+			url: "{{ url_for('ht_api.chartjs_hosts_initial_agent_checkin') }}?startDate=" + getHistoricDate($("#row1_cell2_select").data("id")) + "&endDate=" + currentDate,
 			dataType: 'json',
 		}).done(function (myChartData) {
 
@@ -128,7 +128,7 @@
 
 		// ChartJS: Alerts timeline
 		var jsonData = $.ajax({
-			url: "/api/v1/chartjs_events_timeline?startDate=" + $("#row3_cell1_from").val() + "&endDate=" + $("#row3_cell1_to").val(),
+			url: "{{ url_for('ht_api.chartjs_events_timeline') }}?startDate=" + $("#row3_cell1_from").val() + "&endDate=" + $("#row3_cell1_to").val(),
 			dataType: 'json',
 		}).done(function (myChartData) {
 
@@ -189,7 +189,7 @@
 
 		// ChartJS: alert distribution
 		var jsonData = $.ajax({
-			url: "/api/v1/chartjs_events_distribution?startDate=" + getHistoricDate($("#row2_cell2_select").data("id")) + "&endDate=" + currentDate,
+			url: "{{ url_for('ht_api.chartjs_events_distribution') }}?startDate=" + getHistoricDate($("#row2_cell2_select").data("id")) + "&endDate=" + currentDate,
 			dataType: 'json',
 		}).done(function (myChartData) {
 
@@ -249,7 +249,7 @@
 
 		// ChartJS: inactive hosts
 		var jsonData = $.ajax({
-			url: "/api/v1/chartjs_inactive_hosts_per_hostset?seconds=" + $("#row1_cell1_select").data("id"),
+			url: "{{ url_for('ht_api.chartjs_inactive_hosts_per_hostset') }}?seconds=" + $("#row1_cell1_select").data("id"),
 			dataType: 'json',
 		}).done(function (myChartData) {
 
@@ -312,7 +312,7 @@
 		// Host with the most alerts
 		$.fn.dataTable.ext.errMode = 'none';
 		var row1_cell3_datatable = $('#row1_cell3_table').DataTable( {
-			"ajax": "/api/v1/datatable_hosts_with_alerts",
+			"ajax": "{{ url_for('ht_api.datatable_hosts_with_alerts') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -327,7 +327,7 @@
 				 render: function ( data, type, row, meta ) {
 				 	if(type === 'display'){
 				 		myArr = data.split("___");
-				 		data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(myArr[1]) + '">' + myArr[0] + '</a>';
+				 		data = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + encodeURIComponent(myArr[1]) + '">' + myArr[0] + '</a>';
 				 	}
 				 	return data;
 				 }
@@ -340,7 +340,7 @@
 		// Last 10 alerts
 		$.fn.dataTable.ext.errMode = 'none';
 		var row2_cell1_datatable = $('#row2_cell1_table').DataTable( {
-			"ajax": "/api/v1/datatable_alerts?limit=10",
+			"ajax": "{{ url_for('ht_api.datatable_alerts') }}?limit=10",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -360,7 +360,7 @@
 				 render: function ( data, type, row, meta ) {
 				 	if(type === 'display'){
 				 		myArr = data.split("___");
-				 		data = '<a class="hostLink" href="/hostview?host=' + encodeURIComponent(myArr[1]) + '&alertid=' + encodeURIComponent(myArr[2]) + '">' + myArr[0] + '</a>';
+				 		data = '<a class="hostLink" href="{{ url_for('ht_frontend.host_view') }}?host=' + encodeURIComponent(myArr[1]) + '&alertid=' + encodeURIComponent(myArr[2]) + '">' + myArr[0] + '</a>';
 				 	}
 				 	return data;
 				 }

--- a/templates/ht_multifile.html
+++ b/templates/ht_multifile.html
@@ -34,13 +34,13 @@
 }
 
 td.file-rows-control{
-	background: url("static/img/datatables/details_open.png") no-repeat center center;
+	background: url("{{ url_for('static', filename='img/datatables/details_open.png') }}") no-repeat center center;
 }
 td.file-rows-control:hover{
 	cursor: pointer;
 }
 tr.shown td.file-rows-control {
-	background: url("static/img/datatables/details_close.png") no-repeat center center;
+	background: url("{{ url_for('static', filename='img/datatables/details_close.png') }}") no-repeat center center;
 }
 
 table.nested_table th {
@@ -72,7 +72,7 @@ table.nested_table tr:hover {
 				{ extend: "csv", className: "fe-btn", "text": "csv<i class='fe-icon--right fas fa-file'></i>" },
 				{ extend: "excel", className: "fe-btn", "text": "excel<i class='fe-icon--right fas fa-file-excel'></i>" }
 			],
-			"ajax": "/api/v1/datatable_multi_filelisting",
+			"ajax": "{{ url_for('ht_api.datatable_multi_filelisting') }}",
 			"columns": [
 				{ "data": "id" },
 				{ "data": "state" },
@@ -125,7 +125,7 @@ table.nested_table tr:hover {
 					'<td style="width:150px;">'+d.files[i].hostname+'</td>'+
 					'<td>'+d.files[i].path+'</td>';
 				if(d.files[i].downloaded) {
-					file_table +='<td style="width:132px";><button style="margin-right: 6px;"" class="mDownload fe-btn fe-btn--sm fe-btn--hxtool-main" data-url="/download_file?mf_id=' + d.id + "&acq_id=" + d.files[i]['acquisition_id'] + '">download<i class="fe-icon--right fas fa-download"></i></button></td>';
+					file_table +='<td style="width:132px";><button style="margin-right: 6px;"" class="mDownload fe-btn fe-btn--sm fe-btn--hxtool-main" data-url="{{ url_for('ht_frontend.download_multi_file_single') }}?mf_id=' + d.id + "&acq_id=" + d.files[i]['acquisition_id'] + '">download<i class="fe-icon--right fas fa-download"></i></button></td>';
 				}
 				else {
 					file_table +='<td style="width:132px";><button style="margin-right: 6px;"" class="fe-btn fe-btn--sm fe-btn--hxtool-main">waiting<i class="fe-icon--right fas fa-clock"></i></button></td>';
@@ -143,7 +143,7 @@ table.nested_table tr:hover {
 				{ extend: "csv", className: "fe-btn", "text": "csv<i class='fe-icon--right fas fa-file'></i>" },
 				{ extend: "excel", className: "fe-btn", "text": "excel<i class='fe-icon--right fas fa-file-excel'></i>" }
 			],
-			"ajax": "/api/v1/datatable_multi_multifile",
+			"ajax": "{{ url_for('ht_api.datatable_multi_multifile') }}",
 			"columns": [
 				{
 					"className": 'file-rows-control',
@@ -207,7 +207,7 @@ table.nested_table tr:hover {
 
 		$("#fileListingTable").on("click", ".flistAction", function() {
 			if ($(this).data("type") == "stop") {
-				hxtool_ajax_get_request("/api/v1/acquisition/multi/file_listing/stop", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_multi_file_listing_stop') }}", "id=" + $(this).data("id"), function() {
 					ftable.ajax.reload(function() {
 						$("div[id^='file_listing_prog_']").each(function() {
 							$(this).progressNoAnimate();
@@ -216,11 +216,11 @@ table.nested_table tr:hover {
 				});
 			}
 			if ($(this).data("type") == "view") {
-				location.href = "/file_listing?id=" + $(this).data("id");
+				location.href = "{{ url_for('ht_frontend.file_listing') }}?id=" + $(this).data("id");
 			}
 			if ($(this).data("type") == "remove") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/acquisition/multi/file_listing/remove", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_multi_file_listing_remove') }}", "id=" + $(this).data("id"), function() {
 					myrow.fadeOut(200, function() {
 						ftable.row(myrow).remove().draw();
 					});
@@ -235,7 +235,7 @@ table.nested_table tr:hover {
 		$("#fileAcquisitionTable").on("click", ".mAction", function() {
 			if ($(this).data("type") == "stop") {
 				$(this).find("i").addClass("fa-spin");
-				hxtool_ajax_get_request("/api/v1/acquisition/multi/mf/stop", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_multi_mf_stop') }}", "id=" + $(this).data("id"), function() {
 					setTimeout(function(){ 
 						mtable.ajax.reload(function() {
 							$(this).find("i").removeClass("fa-spin");
@@ -248,7 +248,7 @@ table.nested_table tr:hover {
 			}
 			if ($(this).data("type") == "remove") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/acquisition/multi/mf/remove", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_acquisition_multi_mf_remove') }}", "id=" + $(this).data("id"), function() {
 					myrow.fadeOut(200, function() {
 						mtable.row(myrow).remove().draw();
 					});
@@ -286,7 +286,7 @@ table.nested_table tr:hover {
 				fdata.append("use_raw_mode", true);	
 			}
 
-			hxtool_ajax_post_request("/api/v1/acquisition/multi/file_listing/new", fdata, function() {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_acquisition_multi_file_listing') }}", fdata, function() {
 				ftable.ajax.reload(function() {
 					$("div[id^='file_listing_prog_']").each(function() {
 						$(this).progress();
@@ -298,7 +298,7 @@ table.nested_table tr:hover {
 
 		$("#createFileListing").click(function() {
 
-			hxtool_ajax_get_request("/api/v1/hostsets/list", "", function(setResponse) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hostsets_list') }}", "", function(setResponse) {
 				myResponse = JSON.parse(setResponse['api_response']);
 				myhostentries = [];
 				$.each(myResponse['data']['entries'], function( index, value ) {

--- a/templates/ht_openioc.html
+++ b/templates/ht_openioc.html
@@ -7,7 +7,7 @@
 	$(document).ready(function() {
 
 		$(document).on('click', '.ioc_view', function() {
-			hxtool_ajax_get_request("/api/v1/openioc/view", "id=" + $(this).closest("tr").attr("id"), function(mydata) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_openioc_view') }}", "id=" + $(this).closest("tr").attr("id"), function(mydata) {
 				myIocObject = JSON.parse(mydata['api_response']);
 				// Why???!?
 				myIocObject = JSON.parse(myIocObject);
@@ -24,7 +24,7 @@
 
 		var iocTable = $('#iocTable').DataTable( {
 			"ajax": {
-				"url": "/api/v1/datatable_openioc",
+				"url": "{{ url_for('ht_api.datatable_openioc') }}",
 				"dataSrc": ""
 			},
 			"rowId": 'ioc_id',
@@ -71,13 +71,13 @@
 		});
 
 		$("#iocTable").on('click', '.ioc_download', function() {
-			location.href = "/api/v1/openioc/download?id=" + $(this).data("id")
+			location.href = "{{ url_for('ht_api.hxtool_api_openioc_download') }}?id=" + $(this).data("id")
 
 		});
 
 		$("#iocTable").on('click', '.ioc_remove', function() {
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/openioc/remove", "id=" + $(this).data("id"), function() {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_openioc_remove') }}", "id=" + $(this).data("id"), function() {
 				myrow.fadeOut(200, function() {
 					iocTable.row(myrow).remove().draw();
 				});
@@ -94,7 +94,7 @@
 
 			data.append("iocname", $("#iocname").val());
 
-			hxtool_ajax_post_request("/api/v1/openioc/upload", data, function(data) {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_openioc_upload') }}", data, function(data) {
 				iocTable.ajax.reload();
 				$("#openiocNewPopup").hide();
 			});

--- a/templates/ht_scheduler.html
+++ b/templates/ht_scheduler.html
@@ -6,7 +6,7 @@
 <script>
 	$(document).ready(function() {
 
-		$.getJSON('/api/v1/scheduler_health', function(myhealth) {
+		$.getJSON('{{ url_for('ht_api.scheduler_health') }}', function(myhealth) {
 			if (myhealth == true) {
 				$("#schedulerHealth").html("<i class='fas fa-check-circle fa-1x fa-fw' style='color: green; margin-right: 2px;' aria-hidden='true'></i> The scheduler is running");
 			}
@@ -16,7 +16,7 @@
 		});
 
 		var scheduler_tasks = $('#tableContainer').DataTable( {
-			"ajax": "/api/v1/scheduler_tasks",
+			"ajax": "{{ url_for('ht_api.scheduler_tasks') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -88,7 +88,12 @@
 		$("#tableContainer").on("click", ".schedulerAction", function(){
 			mytype = $(this).data("type");
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/scheduler/" + $(this).data("type"), "id=" + $(this).data("id"), function() {
+
+			const urlMap = new Map();
+			urlMap.set('remove', '{{ url_for('ht_api.hxtool_api_scheduler_remove') }}');
+			
+
+			hxtool_ajax_get_request(urlMap.get($(this).data("type")), "id=" + $(this).data("id"), function() {
 				if (mytype == "remove") {
 					myrow.fadeOut(200, function() {
 						scheduler_tasks.row(myrow).remove().draw();

--- a/templates/ht_scriptbuilder.html
+++ b/templates/ht_scriptbuilder.html
@@ -298,12 +298,12 @@
 				$.ajax
 				({
 					type: "POST",
-					url: '/api/v1/scripts/builder',
+					url: '{{ url_for('ht_api.hxtool_api_scripts_builder') }}',
 					dataType: 'json',
 					contentType: 'application/json',
 					data: JSON.stringify(myData, null, 4),
 					success: function () {
-						window.location.href = "/scripts";
+						window.location.href = "{{ url_for('static') }}/scripts";
 					},
 					error: function (xhr, status) {
 						$("#hxtoolMessageBody").html(JSON.stringify(xhr['responseText']));

--- a/templates/ht_scripts.html
+++ b/templates/ht_scripts.html
@@ -36,7 +36,7 @@
 
 			data.append("scriptname", $("#scriptname").val());
 
-			hxtool_ajax_post_request("/api/v1/scripts/upload", data, function(data) {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_scripts_upload') }}", data, function(data) {
 				$("#scriptNewPopup").hide();
 				scriptTable.ajax.reload();
 			});
@@ -44,7 +44,7 @@
 
 		$("#scriptTable").on('click', '.script_remove', function() {
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/scripts/remove", "id=" + $(this).data("id"), function(mydata) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_scripts_remove') }}", "id=" + $(this).data("id"), function(mydata) {
 				myrow.fadeOut(200, function() {
 					scriptTable.row(myrow).remove().draw();
 				});
@@ -52,12 +52,12 @@
 		});
 
 		$("#scriptTable").on('click', '.script_download', function() {
-			location.href = "/api/v1/scripts/download?id=" + $(this).data("id");
+			location.href = "{{ url_for('ht_api.hxtool_api_scripts_download') }}?id=" + $(this).data("id");
 		});
 
 		var scriptTable = $('#scriptTable').DataTable( {
 			"ajax": {
-				"url": "/api/v1/datatable_scripts",
+				"url": "{{ url_for('ht_api.datatable_scripts') }}",
 				"dataSrc": ""
 			},
 			"paging":   false,
@@ -81,7 +81,7 @@
 				 width: "320px",
 				 render: function ( data, type, row, meta ) {
 				 	if(type === 'display'){
-				 		//data = "<input type='button' data-script='" + row.script + "' value='view' id='view_" + data + "' class='tableActionButton viewbutton'><a href='/scripts?action=delete&id=" + data + "' class='tableActionButton'>delete</a>";
+				 		//data = "<input type='button' data-script='" + row.script + "' value='view' id='view_" + data + "' class='tableActionButton viewbutton'><a href='{{ url_for('ht_frontend.scripts') }}?action=delete&id=" + data + "' class='tableActionButton'>delete</a>";
 				 		data = '<button style="margin-right: 6px;" data-script="' + row.script + '" class="script_view fe-btn fe-btn--sm fe-btn--primary fe-btn--hxtool-main"> view <i class="fe-icon--right fas fa-eye"></i></button>';
 				 		data += '<button style="margin-right: 6px;" data-id="' + row.script_id + '" class="script_download fe-btn fe-btn--sm fe-btn--primary fe-btn--hxtool-main"> download <i class="fe-icon--right fas fa-download"></i></button>'
 				 		data += '<button style="margin-right: 6px;" data-id="' + row.script_id + '" class="script_remove fe-btn fe-btn--sm fe-btn--primary fe-btn--hxtool-main-remove"> remove <i class="fe-icon--right fas fa-trash"></i></button>';

--- a/templates/ht_search_dd.html
+++ b/templates/ht_search_dd.html
@@ -7,12 +7,12 @@
 	$(document).ready(function() {
 
 		$("#goBack").click(function(){
-			location.href = "/search";
+			location.href = "{{ url_for('ht_frontend.search') }}";
 		});
 
 		myid = getQueryParam('id');
 
-		$.getJSON('/api/v1/datatable_es_result_types?id=' + myid, function(mytypes) {
+		$.getJSON('{{ url_for('ht_api.datatable_es_result_types') }}?id=' + myid, function(mytypes) {
 
 			for (var currtype in mytypes) {
 				var mycols = [];
@@ -31,7 +31,7 @@
 
 				$.fn.dataTable.ext.errMode = 'none';
 				$('#esTableResults_' + currtype.replace(/ /g,"_")).DataTable( {
-					"ajax": "/api/v1/datatable_es_result?id=" + myid + "&type=" + currtype,
+					"ajax": "{{ url_for('ht_api.datatable_es_result_types') }}?id=" + myid + "&type=" + currtype,
 					"columns": mycols,
 					"paging":   true,
 					"ordering": true,
@@ -52,7 +52,7 @@
 						{
 						 "targets": 0,
 						 render: function ( data, type, row, meta ) {
-						 	return(datatables_parseHostlink(data));
+						 	return(datatables_parseHostlink(data, "{{ url_for('ht_frontend.host_view') }}"));
 						 }
 						}					
 					]

--- a/templates/ht_searchsweep.html
+++ b/templates/ht_searchsweep.html
@@ -13,7 +13,7 @@
 
 		$.fn.dataTable.ext.errMode = 'none';
 		var es_datatable = $('#esTable').DataTable( {
-			"ajax": "/api/v1/datatable_es",
+			"ajax": "{{ url_for('ht_api.datatable_es') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,
@@ -62,7 +62,7 @@
 				 "width": "50px",
 				 render: function ( data, type, row, meta ) {
 				 	if(type === 'display') {
-				 		data = '<a style="margin: 0;" class="fe-radio__label" href="/searchresult?id=' + row.DT_RowId + '">' + data + '</a>';
+				 		data = '<a style="margin: 0;" class="fe-radio__label" href="{{ url_for('ht_frontend.searchresult') }}?id=' + row.DT_RowId + '">' + data + '</a>';
 				 	}
 				 	return data;
 				 }
@@ -71,7 +71,7 @@
 				 "targets": [ 2 ],
 				 render: function ( data, type, row, meta ) {
 				 	if(type === 'display') {
-				 		data = '<span class="searchname"><a style="margin: 0;" class="fe-radio__label" href="/searchresult?id=' + row.DT_RowId + '">' + data + '</a></span>';
+				 		data = '<span class="searchname"><a style="margin: 0;" class="fe-radio__label" href="{{ url_for('ht_frontend.searchresult') }}?id=' + row.DT_RowId + '">' + data + '</a></span>';
 				 		data += '<div style="display: none; position: absolute; border: 1px solid rgba(15, 184, 220, 0.4); padding: 15px; background: #2c3138; border-radius: 3px;">';
 				 		data += '<h5>Underlying bulk acquisition</h5>';
 				 		data += '<table class="hxtool_table"><thead>';
@@ -172,11 +172,17 @@
 		$("#esTable").on("click", ".esAction", function(){
 			mytype = $(this).data("type");
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/enterprise_search/" + $(this).data("type"), "id=" + $(this).data("id"), function() {
+
+			const urlMap = new Map();
+			urlMap.set('stop', '{{ url_for('ht_api.hxtool_api_enterprise_search_stop') }}')
+			urlMap.set('remove', '{{ url_for('ht_api.hxtool_api_enterprise_search_remove') }}')
+			
+
+			hxtool_ajax_get_request(urlMap.get($(this).data("type")), "id=" + $(this).data("id"), function() {
 				if (mytype == "remove") {
 					myrow.fadeOut(200, function() {
 						es_datatable.row(myrow).remove().draw();
-						updateChartJS(chartjs_searches, "/api/v1/enterprise_search/chartjs_searches?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
+						updateChartJS(chartjs_searches, "{{ url_for('ht_api.hxtool_api_enterprise_search_chartjs_searches') }}?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
 					})
 				}
 				else {
@@ -202,11 +208,11 @@
 			
 			// Set the endpoint and IOC Data
 			if (mymode == "hxtool") {
-				myApiEndpoint = "/api/v1/enterprise_search/new/db";
+				myApiEndpoint = "{{ url_for('ht_api.hxtool_api_enterprise_search_new_db') }}";
 				data.append("ioc", $("#esIocDb").data("id"));
 			}
 			else if (mymode == "file") {
-				myApiEndpoint = "/api/v1/enterprise_search/new/file";
+				myApiEndpoint = "{{ url_for('ht_api.hxtool_api_enterprise_search_new_file') }}";
 				$.each($('#esIocFile').prop('files'), function(key, value) {
 					data.append("ioc", value);
 				});
@@ -246,11 +252,11 @@
 									$(this).progressNoAnimate();
 								});
 							});
-							updateChartJS(chartjs_searches, "/api/v1/enterprise_search/chartjs_searches?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
+							updateChartJS(chartjs_searches, "{{ url_for('ht_api.hxtool_api_enterprise_search_chartjs_searches') }}?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
 						}, 1000 );
 					}
 					else {
-						location.href = "/scheduler";
+						location.href = "{{ url_for('ht_frontend.scheduler_view') }}";
 					}
 				});
 			}
@@ -263,11 +269,11 @@
 									$(this).progressNoAnimate();
 								});
 							});
-							updateChartJS(chartjs_searches, "/api/v1/enterprise_search/chartjs_searches?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
+							updateChartJS(chartjs_searches, "{{ url_for('ht_api.hxtool_api_enterprise_search_chartjs_searches') }}?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate);
 						}, 1000 );
 					}
 					else {
-						location.href = "/scheduler";
+						location.href = "{{ url_for('ht_frontend.scheduler_view') }}";
 					}
 				});
 			}
@@ -281,7 +287,7 @@
 
 		// ChartJS: Historical searches
 		var jsonData = $.ajax({
-			url: "/api/v1/enterprise_search/chartjs_searches?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate,
+			url: "{{ url_for('ht_api.hxtool_api_enterprise_search_chartjs_searches') }}?startDate=" + getHistoricDate(7) + "&endDate=" + currentDate,
 			dataType: 'json',
 		}).done(function (myChartData) {
 

--- a/templates/ht_settings.html
+++ b/templates/ht_settings.html
@@ -8,7 +8,7 @@
 	$(document).ready(function() {
 
 		$("#unset").click(function() {
-			location.href = "/settings?unset=1";
+			location.href = "{{ url_for('ht_frontend.settings') }}?unset=1";
 		});
 
 	});

--- a/templates/ht_stacking.html
+++ b/templates/ht_stacking.html
@@ -6,7 +6,7 @@
 <script>
 	$(document).ready(function() {
 
-		hxtool_ajax_get_request("/api/v1/hostsets/list", "", function(setResponse) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hostsets_list') }}", "", function(setResponse) {
 			myHostSetResponse = JSON.parse(setResponse['api_response']);
 			myhostsets = {};
 			$.each(myHostSetResponse['data']['entries'], function( index, value ) {
@@ -14,7 +14,7 @@
 			});
 
 			stacking_datatable = $('#stackingTable').DataTable( {
-				"ajax": "/api/v1/datatable_stacking",
+				"ajax": "{{ url_for('ht_api.datatable_stacking') }}",
 				"paging":   false,
 				"ordering": false,
 				"info":     false,
@@ -102,18 +102,18 @@
 
 		$("#stackingTable").on("click", ".stackAction", function() {
 			if ($(this).data("type") == "analyze") {
-				location.href = "/stackinganalyze?id=" + $(this).data("id");
+				location.href = "{{ url_for('ht_frontend.stackinganalyze') }}?id=" + $(this).data("id");
 			}
 			else if ($(this).data("type") == "remove") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/stacking/remove", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_stacking_remove') }}", "id=" + $(this).data("id"), function() {
 					myrow.fadeOut(200, function() {
 						stacking_datatable.row(myrow).remove().draw();
 					});
 				});
 			}
 			else if ($(this).data("type") == "stop") {
-				hxtool_ajax_get_request("/api/v1/stacking/stop", "id=" + $(this).data("id"), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_stacking_stop') }}", "id=" + $(this).data("id"), function() {
 					stacking_datatable.ajax.reload(function() {
 						$("div[id^='crate_']").each(function() {
 							$(this).progressNoAnimate();
@@ -126,7 +126,7 @@
 		$("#stackingNew").click(function() {
 			$("#stackingPopup").find(".fe-modal__body").html("");
 
-			hxtool_ajax_get_request("/api/v1/stacking/stacktypes", "", function(typeResponse) {
+			hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_stacking_stacktypes') }}", "", function(typeResponse) {
 				myentries = [];
 				$.each(typeResponse, function( index, value ) {
 					myentries.push({
@@ -139,7 +139,7 @@
 				$("#stackingPopup").find(".fe-modal__body").append(generateDropDown(myentries[0]['elementText'], "stack_type", myentries[0]['elementId'], entries=myentries, "", ""));
 				$("#stackingPopup").find(".fe-modal__body").append("<br>");
 			
-				hxtool_ajax_get_request("/api/v1/hostsets/list", "", function(setResponse) {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_hostsets_list') }}", "", function(setResponse) {
 					myResponse = JSON.parse(setResponse['api_response']);
 					myhostentries = [];
 					$.each(myResponse['data']['entries'], function( index, value ) {
@@ -172,7 +172,7 @@
 			data.append("stack_type", $("#stack_type").data("id"));
 			data.append("stackhostset", $("#stackhostset").data("id"));
 
-			hxtool_ajax_post_request("/api/v1/stacking/new", data, function() {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_stacking_new') }}", data, function() {
 				stacking_datatable.ajax.reload(function() {
 					$("div[id^='crate_']").each(function() {
 						$(this).progressNoAnimate();

--- a/templates/ht_stacking_analyze.html
+++ b/templates/ht_stacking_analyze.html
@@ -7,7 +7,7 @@
 	$(document).ready(function() {
 
 		$("#backButton").click(function(){
-			location.href = "/stacking";
+			location.href = "{{ url_for('ht_frontend.stacking') }}";
 		});
 
 		$("#endpointViewDismiss").click(function(){
@@ -23,7 +23,7 @@
 		myid = getQueryParam('id');
 		$.ajax({
 				type: "GET",
-				url: "/api/v1/stacking/" + myid + "/results",
+				url: "{{ url_for('ht_api.stack_job_results') }}/" + myid,
 				contentType: "application/json; charset=utf-8",
 				dataType: "json",
 				success: function(r) {

--- a/templates/ht_streaming_indicator_create_edit.html
+++ b/templates/ht_streaming_indicator_create_edit.html
@@ -211,7 +211,7 @@
 			//{% endif %}
 
 			// Render categories
-			//hxtool_ajax_get_request("/api/v1/indicator_category/list", "", function(setResponse) {
+			//hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_indicator_category_list') }}", "", function(setResponse) {
 			//	myCategoryResponse = JSON.parse(setResponse['api_response']);
 			//	mycats = [];
 			//	$.each(myCategoryResponse['data']['entries'], function( index, value ) {
@@ -348,8 +348,8 @@
 					var myForm = new FormData();
 					myForm.append("rule", JSON.stringify(data));
 
-					hxtool_ajax_post_request("/api/v1/streaming_indicators/newOrUpdate", myForm, function() {
-						location.href = "/streaming_indicators";
+					hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_streaming_indicators_newOrUpdate') }}", myForm, function() {
+						location.href = "{{ url_for('ht_frontend.streaming_indicators') }}";
 					});
 
 				}

--- a/templates/ht_streaming_indicators.html
+++ b/templates/ht_streaming_indicators.html
@@ -33,7 +33,7 @@
 
 	$(document).ready(function() {
 
-		hxtool_ajax_get_request("/api/v1/streaming_indicator_category/get_edit_policies", "", function(myCategoryPolicies) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_streaming_indicator_category_get_edit_policies') }}", "", function(myCategoryPolicies) {
 			myEditPolicies = JSON.parse(myCategoryPolicies['api_response']);
 			const xOpts = {	// see: https://datatables.net/reference/api/buttons.exportData()
 				orthogonal: 'export',
@@ -41,7 +41,7 @@
 				};
 
 			ioc_datatable = $('#iocTable').DataTable( {
-				"ajax": "/api/v1/datatable_streaming_indicators",
+				"ajax": "{{ url_for('ht_api.datatable_streaming_indicators') }}",
 				"paging":   false,
 				"ordering": false,
 				"info":     false,
@@ -162,14 +162,14 @@
 
 		$("#iocTable").on("click", ".iocAction", function() {
 			if ($(this).data("type") == "edit") {
-				location.href = "/streamingioc?indicator=" + encodeURIComponent($(this).data("url"));
+				location.href = "{{ url_for('ht_frontend.streamingioc') }}?indicator=" + encodeURIComponent($(this).data("url"));
 			}
 			if ($(this).data("type") == "clone") {
-				location.href = "/streamingioc?indicator=" + encodeURIComponent($(this).data("url")) + "&clone=true";
+				location.href = "{{ url_for('ht_frontend.streamingioc') }}?indicator=" + encodeURIComponent($(this).data("url")) + "&clone=true";
 			}
 			if ($(this).data("type") == "remove") {
 				myrow = $(this).closest("tr");
-				hxtool_ajax_get_request("/api/v1/streaming_indicators/remove", "id=" + encodeURIComponent($(this).data("id")), function() {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_streaming_indicators_remove') }}", "id=" + encodeURIComponent($(this).data("id")), function() {
 					myrow.fadeOut(200, function() {
 						ioc_datatable.row(myrow).remove().draw();
 					});
@@ -191,13 +191,13 @@
 				data["id"] = $(this).data("id");
 				data["is_enabled"] = is_enabled;
 				form.append('data', JSON.stringify(data))
-				hxtool_ajax_post_request("/api/v1/streaming_indicators/enable", form, function() {
+				hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_streaming_indicators_enable') }}", form, function() {
 					$("#hxtoolMessageBody").html(msg);
 					$("#hxtoolMessage").show();
 				});
 			}
 			if ($(this).data("type") == "view") {
-				hxtool_ajax_get_request("/api/v1/streaming_indicators/get/conditions", "uuid=" + $(this).data("id"), function(myConditionsResponse) {
+				hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_streaming_indicators_get_conditions') }}", "uuid=" + $(this).data("id"), function(myConditionsResponse) {
 					myConditions = JSON.parse(myConditionsResponse['api_response']);
 
 					// First empty the container
@@ -237,7 +237,7 @@
 
 			data.append('platform', $('#ruleImportPlatform').data("id"));
 			
-			hxtool_ajax_post_request("/api/v1/streaming_indicators/import", data, function() {
+			hxtool_ajax_post_request("{{ url_for('ht_api.hxtool_api_streaming_indicators_import') }}", data, function() {
 				ioc_datatable.ajax.reload();
 			});
 
@@ -263,7 +263,7 @@
 			$.ajax
 			({
 				type: 'POST',
-				url: '/api/v1/streaming_indicators/export',
+				url: '{{ url_for('ht_api.hxtool_api_streaming_indicators_export') }}',
 				contentType: 'application/json',
 				xhrFields: { responseType: 'blob' },
 				processData: false,
@@ -303,7 +303,7 @@
 		});
 
 		$("#createButton").click(function() {
-			location.href = "/streamingioc";
+			location.href = "{{ url_for('ht_frontend.streamingioc') }}";
 		});
 		
 	});

--- a/templates/ht_sysinfo.html
+++ b/templates/ht_sysinfo.html
@@ -5,7 +5,7 @@
 <script>
 	$(document).ready(function() {
 
-		hxtool_ajax_get_request("/api/v1/version/get", "", function(res) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.hxtool_api_version_get') }}", "", function(res) {
 			myVersion = JSON.parse(res['api_response']);
 			$("#hxVersionContainer").append(hxtoolGenerateNestedTable(myVersion['data']));
 		});
@@ -24,7 +24,7 @@
 
 		$("#hxtoolVersionContainer").append(hxtoolGenerateNestedTable(hxToolInfo));
 
-		hxtool_ajax_get_request("/api/v1/cache/statistics", "", function(cacheStats) {
+		hxtool_ajax_get_request("{{ url_for('ht_api.cache_statistics') }}", "", function(cacheStats) {
 			$("#CacheStatContainer").append(hxtoolGenerateNestedTable(cacheStats));
 		});
 

--- a/templates/ht_taskprofile.html
+++ b/templates/ht_taskprofile.html
@@ -31,7 +31,11 @@
 		$("#taskprofileTable").on("click", ".tpAction", function(){
 			mytype = $(this).data("type");
 			myrow = $(this).closest("tr");
-			hxtool_ajax_get_request("/api/v1/taskprofile/" + $(this).data("type"), "id=" + $(this).data("id"), function() {
+			const urlMap = new Map();
+			urlMap.set('remove', '{{ url_for('ht_api.hxtool_api_taskprofile_remove') }}')
+			urlMap.set('new', '{{ url_for('ht_api.hxtool_api_taskprofile_new') }}')
+
+			hxtool_ajax_get_request(urlMap.get($(this).data("type")), "id=" + $(this).data("id"), function() {
 				if (mytype == "remove") {
 					myrow.fadeOut(200, function() {
 						taskprofileTable.row(myrow).remove().draw();
@@ -100,7 +104,7 @@
 			$.ajax
 			({
 				type: "POST",
-				url: '/api/v1/taskprofile/new',
+				url: '{{ url_for('ht_api.hxtool_api_taskprofile_new') }}',
 				dataType: 'json',
 				contentType: 'application/json',
 				data: JSON.stringify(myTasks),
@@ -192,7 +196,7 @@
 
 		var taskprofileTable = $('#taskprofileTable').DataTable( {
 			"ajax": {
-				"url": "/api/v1/datatable_taskprofiles",
+				"url": "{{ url_for('ht_api.datatable_taskprofiles') }}",
 				"dataSrc": ""
 			},
 			"paging":   false,

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -23,21 +23,21 @@
 	<script type="text/javascript" src="{{ url_for('static', filename='js/buttons.print.min.js') }}"></script>
 	<script type="text/javascript" src="{{ url_for('static', filename='js/jszip.min.js') }}"></script>
 	<script type="text/javascript" src="{{ url_for('static', filename='js/datatables_parser.js') }}"></script>
-	<script type="text/javascript" src="/static/datetimepicker/moment.min.js"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='datetimepicker/moment.min.js') }}"></script>
 	<script type="text/javascript" src="{{ url_for('static', filename='ChartJS/Chart.min.js') }}"></script>
 	<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/buttons.dataTables.min.css') }}" />
-	<script type="text/javascript" src="/static/progress.js"></script>
-	<script type="text/javascript" src="/static/jquery.multi-select.js"></script>
-	<script type="text/javascript" src="/static/datetimepicker/daterangepicker.js"></script>
-	<script type="text/javascript" src="/static/hxtool-js/hxtool-doc-ready.js"></script>
-	<script type="text/javascript" src="/static/hxtool-js/hxtool-generic.js"></script>
-	<script type="text/javascript" src="/static/hxtool-js/hxtool-widgets.js"></script>
-	<link href="/static/fontawesome-free-5.7.2-web/css/all.css" rel="stylesheet">
-	<link href="/static/fe-fds/fds-dark.css" rel="stylesheet" />
-	<link rel="stylesheet" type="text/css" href="static/hxtool-css/hxtool-main.css">
-    <link rel="stylesheet" type="text/css" href="static/datetimepicker/daterangepicker.css">
-	<link rel="stylesheet" type="text/css" href="static/multi-select.css">
-	<link href="/static/favicon.ico" rel="icon" type="image/x-icon" />
+	<script type="text/javascript" src="{{ url_for('static', filename='progress.js') }}"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='jquery.multi-select.js') }}"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='datetimepicker/daterangepicker.js') }}"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='hxtool-js/hxtool-doc-ready.js') }}"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='hxtool-js/hxtool-generic.js') }}"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='hxtool-js/hxtool-widgets.js') }}"></script>
+	<link href="{{ url_for('static', filename='fontawesome-free-5.7.2-web/css/all.css') }}" rel="stylesheet">
+	<link href="{{ url_for('static', filename='fe-fds/fds-dark.css') }}" rel="stylesheet" />
+	<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='hxtool-css/hxtool-main.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='datetimepicker/daterangepicker.css') }}">
+	<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='multi-select.css') }}">
+	<link href="{{ url_for('static', filename='favicon.ico') }}" rel="icon" type="image/x-icon" />
 </head>
 <body>
 	<script>
@@ -118,7 +118,10 @@
 				$("#topnav_iocstreaming").hide();
 			}
 
-			hxtool_doc_ready();
+			hxtool_doc_ready(
+				'{{ url_for('ht_frontend.hosts') }}',
+				'{{ url_for('ht_frontend.logout') }}'
+			);
 
 		});
 	</script>
@@ -132,7 +135,7 @@
 	<!-- TOP NAV BAR -->
 	<header class="fe-top-nav fe-top-nav__topnav">
 		<div class="fe-top-nav__title fe-top-nav__bookend--left fe-top-nav__bookend">
-			<a class="fe-top-nav__home" routerlink="/">
+			<a class="fe-top-nav__home" routerlink="{{ url_for('ht_frontend.dashboard') }}">
 				<div class="fe-top-nav__title-brand">FireEye<sup>®</sup></div>
 				<div class="fe-top-nav__title-name">HXTool</div>
 			</a>
@@ -146,13 +149,13 @@
 						<i class="fas fa-chevron-down"></i>
 					</button>
 					<div class='hxtool_topnav_dropdown'>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/'>Main Dashboard</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/dashboard-agent'>Agent Dashboard</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/dashboard-av'>Antivirus Dashboard</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.dashboard') }}'>Main Dashboard</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.dashboardagent') }}'>Agent Dashboard</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.dashboardav') }}'>Antivirus Dashboard</button><br>
 					</div>
 				</li>
 				<li class="fe-top-nav__bar-nav-items">
-					<button class="hxtool_topnav_mainbutton fe-btn fe-btn--lg fe-btn--primary-link" data-link='/alert' aria-label="item 2">
+					<button class="hxtool_topnav_mainbutton fe-btn fe-btn--lg fe-btn--primary-link" data-link='{{ url_for('ht_frontend.alert') }}' aria-label="item 2">
 						<i class='fas fa-exclamation-triangle' aria-hidden='true'></i>
 						<span>alerts</span>
 					</button>
@@ -164,8 +167,8 @@
 						<i class="fas fa-chevron-down"></i>
 					</button>
 					<div class='hxtool_topnav_dropdown'>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/search'>OpenIOC search</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/openioc'>Manage OpenIOC indicators</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.search') }}'>OpenIOC search</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.openioc') }}'>Manage OpenIOC indicators</button><br>
 					</div>
 				</li>
 				<li class="fe-top-nav__bar-nav-items">
@@ -175,15 +178,15 @@
 						<i class="fas fa-chevron-down"></i>
 					</button>
 					<div class='hxtool_topnav_dropdown'>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/scriptbuilder'>script builder</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/scripts'>manage scripts</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/auditexplorer' id='topnav_auditexplorer'>audit explorer</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/auditmanager' id='topnav_manageaudits'>manage audits</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/acqs'>acquisitions</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/bulkacq'>bulk acquisitions</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/multifile'>multi-file acquisitions</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/stacking'>data stacking</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/taskprofile'>task profiles</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.scriptbuilder_view') }}'>script builder</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.scripts') }}'>manage scripts</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.auditexplorer') }}' id='topnav_auditexplorer'>audit explorer</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.auditmanager') }}' id='topnav_manageaudits'>manage audits</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.acqs') }}'>acquisitions</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.bulkacq_view') }}'>bulk acquisitions</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.multifile') }}'>multi-file acquisitions</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.stacking') }}'>data stacking</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.taskprofile') }}'>task profiles</button><br>
 					</div>
 				</li>
 				<li class="fe-top-nav__bar-nav-items">
@@ -194,12 +197,12 @@
 					</button>
 					<div class='hxtool_topnav_dropdown'>
 						<label class='hxtool_topnav_dropdown_divider fe-label'>Alerting</label><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/rtioc'>build rule</button><br>
-						<!--<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/indicatorqueue'>rule queue</button><br>-->
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/indicators'>manage rules</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/categories'>manage rule categories</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.rtioc') }}'>build rule</button><br>
+						<!--<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.indicatorsqueue') }}'>rule queue</button><br>-->
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.indicators') }}'>manage rules</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.categories') }}'>manage rule categories</button><br>
 						<label class='hxtool_topnav_dropdown_divider fe-label' id='topnav_iocstreaming_label'>Streaming</label><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/streaming_indicators' id='topnav_iocstreaming'>manage streaming rules</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.streaming_indicators') }}' id='topnav_iocstreaming'>manage streaming rules</button><br>
 					</div>
 				</li>
 				<li class="fe-top-nav__bar-nav-items">
@@ -209,9 +212,9 @@
 						<i class="fas fa-chevron-down"></i>
 					</button>
 					<div class='hxtool_topnav_dropdown'>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/channels'>custom configuration channels</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/scheduler'>scheduler</button><br>
-						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='/settings'>hxtool settings</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.channels') }}'>custom configuration channels</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.scheduler_view') }}'>scheduler</button><br>
+						<button class='hxtool_topnav_dropdown_child fe-btn fe-btn--lg fe-btn--primary-link' data-link='{{ url_for('ht_frontend.settings') }}'>hxtool settings</button><br>
 					</div>
 				</li>
 				<li class="fe-top-nav__bar-nav-items" id="fe-top-nav__bar-right-item">
@@ -227,7 +230,7 @@
 				<a aria-label="search in topnav" id="hxtool_topnavSearch" class="fe-top-nav__action-item" data-clicked='false' role="button" tabindex="0" aria-expanded="false">
 					<i class="fe-icon--center fas fa-search fa-2x"></i>
 				</a>
-				<a aria-label="info in topnav" class="fe-top-nav__action-item" href="/sysinfo" role="button" tabindex="0" aria-expanded="false">
+				<a aria-label="info in topnav" class="fe-top-nav__action-item" href="{{ url_for('ht_frontend.sysinfo') }}" role="button" tabindex="0" aria-expanded="false">
 					<i class="fe-icon--center fas fa-info-circle fa-2x"></i>
 				</a>
 				<a id="hxtoolLogout" aria-label="logout" class="fe-top-nav__action-item" role="button" tabindex="0" aria-expanded="false">

--- a/templates/voltron_data.html
+++ b/templates/voltron_data.html
@@ -9,7 +9,7 @@
 		
 		$.fn.dataTable.ext.errMode = 'none';
 		var host_datatable = $('#dataTable').DataTable( {
-			"ajax": "/api/v1/analysis/data",
+			"ajax": "{{ url_for('ht_api.x15_analysis_data') }}",
 			"paging":   false,
 			"ordering": false,
 			"info":     false,


### PR DESCRIPTION
We want to be able to run the hxtool behind a nginx reverse proxy along with other tools, and need to have it run off of a 'sub folder'/url_prefix. like https://localhost:8000/hxtool

I updated this app to add support for url_prefixes.
- It also updates all hard-coded urls in templates to variables.
- For some javascript files, the urls are passed to the functions, instead hard coded as well.
- I also broke the core app out into a separate Blueprint so it could support the url_prefix as well.

I was able to test it locally on my laptop, but I haven't thoroughly on a server with proper access to fireeye (login, api, etc).